### PR TITLE
fix: vm should be the vm of the tested component

### DIFF
--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -19,7 +19,9 @@ export class VueWrapper implements WrapperAPI {
   ) {
     this.__vm = vm
     this.__setProps = setProps
-    this.componentVM = this.vm.$refs['VTU_COMPONENT'] as ComponentPublicInstance
+    this.componentVM = this.__vm.$refs[
+      'VTU_COMPONENT'
+    ] as ComponentPublicInstance
     this.__emitted = events
   }
 
@@ -42,7 +44,7 @@ export class VueWrapper implements WrapperAPI {
   }
 
   get vm(): ComponentPublicInstance {
-    return this.__vm
+    return this.componentVM
   }
 
   classes(className?: string) {

--- a/tests/vm.spec.ts
+++ b/tests/vm.spec.ts
@@ -1,0 +1,21 @@
+import { defineComponent, ref } from 'vue'
+
+import { mount } from '../src'
+
+describe('vm', () => {
+  it('returns the component vm', () => {
+    const Component = defineComponent({
+      template: '<div>{{ msg }}</div>',
+      setup() {
+        const msg = 'hello'
+        const isEnabled = ref(true)
+        return { msg, isEnabled }
+      }
+    })
+
+    const wrapper = mount(Component)
+
+    expect((wrapper.vm as any).msg).toBe('hello')
+    expect((wrapper.vm as any).isEnabled).toBe(true)
+  })
+})


### PR DESCRIPTION
It currently returns the vm of the parent element.
With this commit, it now returns the vm of the tested element.

The test showcases the correct behavior: you can reproduce the issue by adding the test to the master banch. It will fail as it returns the vm of the parent which has no msg, isEnabled fields and toggle function.
