### PR TITLE
Add props accessor method

### DIFF
--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -45,6 +45,12 @@ export class VueWrapper implements WrapperAPI {
     return this.__vm
   }
 
+  props(selector?: string) {
+    return selector
+      ? this.componentVM.$props[selector]
+      : this.componentVM.$props
+  }
+
   classes(className?: string) {
     return new DOMWrapper(this.element).classes(className)
   }

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,0 +1,14 @@
+import { mount } from '../src'
+import WithProps from './components/WithProps.vue'
+
+describe('props', () => {
+  it('returns a single prop applied to a component', () => {
+    const wrapper = mount(WithProps, { props: { msg: 'ABC' } })
+    expect(wrapper.props('msg')).toEqual('ABC')
+  })
+
+  it('returns all props applied to a component', () => {
+    const wrapper = mount(WithProps, { props: { msg: 'ABC' } })
+    expect(wrapper.props()).toEqual({ msg: 'ABC' })
+  })
+})

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '../src'
 import WithProps from './components/WithProps.vue'
+import Hello from './components/Hello.vue'
 
 describe('props', () => {
   it('returns a single prop applied to a component', () => {
@@ -10,5 +11,15 @@ describe('props', () => {
   it('returns all props applied to a component', () => {
     const wrapper = mount(WithProps, { props: { msg: 'ABC' } })
     expect(wrapper.props()).toEqual({ msg: 'ABC' })
+  })
+
+  it('returns undefined if props does not exist', () => {
+    const wrapper = mount(WithProps, { props: { msg: 'ABC' } })
+    expect(wrapper.props('foo')).toEqual(undefined)
+  })
+
+  it('returns empty object for components without props', () => {
+    const wrapper = mount(Hello)
+    expect(wrapper.props()).toEqual({})
   })
 })


### PR DESCRIPTION
Mostly useful for the upcoming `stubs` and `findComponent` implementations. 