### PR TITLE
Find by component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -348,6 +348,85 @@ test('findAll', () => {
 })
 ```
 
+### `findComponent`
+
+Finds a Vue Component instance and returns a `VueWrapper` if one is found, otherwise returns `ErrorWrapper`.
+
+**Supported syntax:**
+ 
+* **querySelector** - `findComponent('.component')` - Matches standard query selector.
+* **Name** - `findComponent({ name: 'myComponent' })` - matches PascalCase, snake-case, camelCase
+* **ref** - `findComponent({ ref: 'dropdown' })` - Can be used only on direct ref children of mounted component
+* **SFC** - `findComponent(ImportedComponent)` - Pass an imported component directly.
+
+```vue
+<template>
+  <div class="foo">
+    Foo
+  </div>
+</template>
+<script>
+export default { name: 'Foo' }
+</script>
+``` 
+ 
+```vue
+<template>
+  <div>
+    <span>Span</span>
+    <Foo data-test="foo" ref="foo"/>
+  </div>
+</template>
+```
+
+```js
+test('find', () => {
+  const wrapper = mount(Component)
+
+  wrapper.find('.foo') //=> found; returns VueWrapper
+  wrapper.find('[data-test="foo"]') //=> found; returns VueWrapper
+  wrapper.find({ name: 'Foo' }) //=> found; returns VueWrapper
+  wrapper.find({ name: 'foo' }) //=> found; returns VueWrapper
+  wrapper.find({ ref: 'foo' }) //=> found; returns VueWrapper
+  wrapper.find(Foo) //=> found; returns VueWrapper
+})
+```
+
+### `findAllComponents`
+
+Similar to `findComponent` but finds all Vue Component instances that match the query and returns an array of `VueWrapper`. 
+
+**Supported syntax:**
+ 
+ * **querySelector** - `findAllComponents('.component')`
+ * **Name** - `findAllComponents({ name: 'myComponent' })`
+ * **SFC** - `findAllComponents(ImportedComponent)`
+ 
+**Note** - `Ref` is not supported here.
+ 
+ 
+```vue
+<template>
+  <div>
+    <FooComponent 
+      v-for="number in [1, 2, 3]"
+      :key="number"
+      data-test="number"
+    >
+      {{ number }}
+    </FooComponent>
+  </div>
+</template>
+```
+
+```js
+test('findAllComponents', () => {
+  const wrapper = mount(Component)
+
+  wrapper.findAllComponents('[data-test="number"]') //=> found; returns array of VueWrapper
+})
+```
+
 ### `trigger`
 
 Simulates an event, for example `click`, `submit` or `keyup`. Since events often cause a re-render, `trigger` returs `Vue.nextTick`. If you expect the event to trigger a re-render, you should use `await` when you call `trigger` to ensure that Vue updates the DOM before you make an assertion.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,3 @@
 export const MOUNT_ELEMENT_ID = 'app'
+export const MOUNT_COMPONENT_REF = 'VTU_COMPONENT'
+export const MOUNT_PARENT_NAME = 'VTU_ROOT'

--- a/src/emitMixin.ts
+++ b/src/emitMixin.ts
@@ -1,7 +1,7 @@
-import { getCurrentInstance, App } from 'vue'
+import { getCurrentInstance } from 'vue'
 
-export const attachEventListener = (vm: App) => {
-  const emitMixin = {
+export const attachEmitListener = () => {
+  return {
     beforeCreate() {
       let events: Record<string, unknown[]> = {}
       this.__emitted = events
@@ -15,6 +15,4 @@ export const attachEventListener = (vm: App) => {
       }
     }
   }
-
-  vm.mixin(emitMixin)
 }

--- a/src/emitMixin.ts
+++ b/src/emitMixin.ts
@@ -1,10 +1,11 @@
-import { getCurrentInstance } from 'vue'
+import { getCurrentInstance, App } from 'vue'
 
-export const createEmitMixin = () => {
-  const events: Record<string, unknown[]> = {}
-
+export const attachEventListener = (vm: App) => {
   const emitMixin = {
     beforeCreate() {
+      let events: Record<string, unknown[]> = {}
+      this.__emitted = events
+
       getCurrentInstance().emit = (event: string, ...args: unknown[]) => {
         events[event]
           ? (events[event] = [...events[event], [...args]])
@@ -15,8 +16,5 @@ export const createEmitMixin = () => {
     }
   }
 
-  return {
-    events,
-    emitMixin
-  }
+  vm.mixin(emitMixin)
 }

--- a/src/error-wrapper.ts
+++ b/src/error-wrapper.ts
@@ -1,9 +1,11 @@
+import { FindComponentSelector } from './types'
+
 interface Options {
-  selector: string
+  selector: FindComponentSelector
 }
 
 export class ErrorWrapper {
-  selector: string
+  selector: FindComponentSelector
   element: null
 
   constructor({ selector }: Options) {
@@ -12,6 +14,10 @@ export class ErrorWrapper {
 
   wrapperError(method: string): Error {
     return Error(`Cannot call ${method} on an empty wrapper.`)
+  }
+
+  vm(): Error {
+    throw this.wrapperError('vm')
   }
 
   attributes() {
@@ -34,8 +40,8 @@ export class ErrorWrapper {
     throw this.wrapperError('findAll')
   }
 
-  setChecked() {
-    throw this.wrapperError('setChecked')
+  setProps() {
+    throw this.wrapperError('setProps')
   }
 
   setValue() {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -14,7 +14,7 @@ import {
 } from 'vue'
 
 import { createWrapper, VueWrapper } from './vue-wrapper'
-import { createEmitMixin } from './emitMixin'
+import { attachEventListener } from './emitMixin'
 import { createDataMixin } from './dataMixin'
 import { MOUNT_ELEMENT_ID } from './constants'
 import { stubComponents } from './stubs'
@@ -145,8 +145,7 @@ export function mount<T extends ComponentPublicInstance>(
   }
 
   // add tracking for emitted events
-  const { emitMixin, events } = createEmitMixin()
-  vm.mixin(emitMixin)
+  attachEventListener(vm)
 
   // stubs
   if (options?.global?.stubs) {
@@ -157,6 +156,6 @@ export function mount<T extends ComponentPublicInstance>(
 
   // mount the app!
   const app = vm.mount(el)
-
-  return createWrapper<T>(app, events, setProps)
+  const App = app.$refs['VTU_COMPONENT'] as ComponentPublicInstance
+  return createWrapper<T>(App, setProps)
 }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -164,6 +164,6 @@ export function mount(
 
   // mount the app!
   const app = vm.mount(el)
-  const App = app.$refs[MOUNT_COMPONENT_REF] as T
+  const App = app.$refs[MOUNT_COMPONENT_REF] as ComponentPublicInstance
   return createWrapper(App, setProps)
 }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -14,9 +14,13 @@ import {
 } from 'vue'
 
 import { createWrapper, VueWrapper } from './vue-wrapper'
-import { attachEventListener } from './emitMixin'
+import { attachEmitListener } from './emitMixin'
 import { createDataMixin } from './dataMixin'
-import { MOUNT_ELEMENT_ID } from './constants'
+import {
+  MOUNT_COMPONENT_REF,
+  MOUNT_ELEMENT_ID,
+  MOUNT_PARENT_NAME
+} from './constants'
 import { stubComponents } from './stubs'
 
 type Slot = VNode | string | { render: Function }
@@ -82,11 +86,11 @@ export function mount<T extends ComponentPublicInstance>(
 
   // we define props as reactive so that way when we update them with `setProps`
   // Vue's reactivity system will cause a rerender.
-  const props = reactive({ ...options?.props, ref: 'VTU_COMPONENT' })
+  const props = reactive({ ...options?.props, ref: MOUNT_COMPONENT_REF })
 
   // create the wrapper component
   const Parent = defineComponent({
-    name: 'VTU_COMPONENT',
+    name: MOUNT_PARENT_NAME,
     render() {
       return h(component, props, slots)
     }
@@ -145,7 +149,7 @@ export function mount<T extends ComponentPublicInstance>(
   }
 
   // add tracking for emitted events
-  attachEventListener(vm)
+  vm.mixin(attachEmitListener())
 
   // stubs
   if (options?.global?.stubs) {
@@ -156,6 +160,6 @@ export function mount<T extends ComponentPublicInstance>(
 
   // mount the app!
   const app = vm.mount(el)
-  const App = app.$refs['VTU_COMPONENT'] as ComponentPublicInstance
+  const App = app.$refs[MOUNT_COMPONENT_REF] as T
   return createWrapper<T>(App, setProps)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,14 @@ export interface WrapperAPI {
   text: () => string
   trigger: (eventString: string) => Promise<(fn?: () => void) => Promise<void>>
 }
+
+interface RefSelector {
+  ref: string
+}
+
+interface NameSelector {
+  name: string
+}
+
+export type FindComponentSelector = RefSelector | NameSelector | string
+export type FindAllComponentsSelector = NameSelector | string

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -37,6 +37,5 @@ function findAllVNodes(vnode: VNode, selector: any) {
 }
 
 export function find(root: VNode, selector: any) {
-  const result = findAllVNodes(root, selector)
-  return result.length ? result[0] : undefined
+  return findAllVNodes(root, selector)
 }

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -2,19 +2,35 @@ import { VNode, ComponentPublicInstance } from 'vue'
 import { FindAllComponentsSelector } from '../types'
 import { matchName } from './matchName'
 
+/**
+ * Detect whether a selector matches a VNode
+ * @param node
+ * @param selector
+ * @return {boolean | ((value: any) => boolean)}
+ */
 function matches(node: VNode, selector: FindAllComponentsSelector): boolean {
+  // do not return none Vue components
+  if (!node.component) return false
+
   if (typeof selector === 'string') {
     return node.el?.matches?.(selector)
   }
+
   if (typeof selector === 'object' && typeof node.type === 'object') {
     if (selector.name && ('name' in node.type || 'displayName' in node.type)) {
       // match normal component definitions or functional components
       return matchName(selector.name, node.type.name || node.type.displayName)
     }
   }
+
   return false
 }
 
+/**
+ * Collect all children
+ * @param nodes
+ * @param children
+ */
 function aggregateChildren(nodes, children) {
   if (children && Array.isArray(children)) {
     ;[...children].reverse().forEach((n: VNode) => {

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,13 +1,15 @@
 import { VNode, ComponentPublicInstance } from 'vue'
+import { FindAllComponentsSelector } from '../types'
+import { matchName } from './matchName'
 
-function matches(node: VNode, selector): boolean {
+function matches(node: VNode, selector: FindAllComponentsSelector): boolean {
   if (typeof selector === 'string') {
     return node.el?.matches?.(selector)
   }
-  if (typeof selector === 'object') {
-    if (selector.name && typeof node.type === 'object') {
-      // @ts-ignore
-      return node.type.name === selector.name
+  if (typeof selector === 'object' && typeof node.type === 'object') {
+    if (selector.name && ('name' in node.type || 'displayName' in node.type)) {
+      // match normal component definitions or functional components
+      return matchName(selector.name, node.type.name || node.type.displayName)
     }
   }
   return false

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,4 +1,4 @@
-import { VNode } from 'vue/dist/vue'
+import { VNode, ComponentPublicInstance } from 'vue'
 
 function matches(node: VNode, selector): boolean {
   if (typeof selector === 'string') {
@@ -21,7 +21,7 @@ function aggregateChildren(nodes, children) {
   }
 }
 
-function findAllVNodes(vnode: VNode, selector: any) {
+function findAllVNodes(vnode: VNode, selector: any): VNode[] {
   const matchingNodes = []
   const nodes = [vnode]
   while (nodes.length) {
@@ -36,6 +36,8 @@ function findAllVNodes(vnode: VNode, selector: any) {
   return matchingNodes
 }
 
-export function find(root: VNode, selector: any) {
-  return findAllVNodes(root, selector)
+export function find(root: VNode, selector: any): ComponentPublicInstance[] {
+  return findAllVNodes(root, selector).map(
+    (vnode: VNode) => vnode.component.proxy
+  )
 }

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,0 +1,42 @@
+import { VNode } from 'vue/dist/vue'
+
+function matches(node: VNode, selector): boolean {
+  if (typeof selector === 'string') {
+    return node.el?.matches?.(selector)
+  }
+  if (typeof selector === 'object') {
+    if (selector.name && typeof node.type === 'object') {
+      // @ts-ignore
+      return node.type.name === selector.name
+    }
+  }
+  return false
+}
+
+function aggregateChildren(nodes, children) {
+  if (children && Array.isArray(children)) {
+    ;[...children].reverse().forEach((n: VNode) => {
+      nodes.unshift(n)
+    })
+  }
+}
+
+function findAllVNodes(vnode: VNode, selector: any) {
+  const matchingNodes = []
+  const nodes = [vnode]
+  while (nodes.length) {
+    const node = nodes.shift()
+    aggregateChildren(nodes, node.children)
+    aggregateChildren(nodes, node.component?.subTree.children)
+    if (matches(node, selector)) {
+      matchingNodes.push(node)
+    }
+  }
+
+  return matchingNodes
+}
+
+export function find(root: VNode, selector: any) {
+  const result = findAllVNodes(root, selector)
+  return result.length ? result[0] : undefined
+}

--- a/src/utils/matchName.ts
+++ b/src/utils/matchName.ts
@@ -1,0 +1,14 @@
+import { camelize, capitalize } from '@vue/shared'
+
+export function matchName(target, sourceName) {
+  const camelized = camelize(target)
+  const capitalized = capitalize(camelized)
+
+  return (
+    sourceName &&
+    (sourceName === target ||
+      sourceName === camelized ||
+      sourceName === capitalized ||
+      capitalize(camelize(sourceName)) === capitalized)
+  )
+}

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -88,18 +88,16 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return result
   }
 
-  findComponent(selector: FindComponentSelector): VueWrapper | ErrorWrapper {
+  findComponent(selector: FindComponentSelector): VueWrapper<T> | ErrorWrapper {
     if (typeof selector === 'object' && 'ref' in selector) {
-      return createWrapper(
-        this.vm.$refs[selector.ref] as ComponentPublicInstance
-      )
+      return createWrapper(this.vm.$refs[selector.ref] as T)
     }
     const result = find(this.vm.$.subTree, selector)
     if (!result.length) return new ErrorWrapper({ selector })
     return createWrapper(result[0])
   }
 
-  findAllComponents(selector: FindAllComponentsSelector): VueWrapper[] {
+  findAllComponents(selector: FindAllComponentsSelector): VueWrapper<T>[] {
     return find(this.vm.$.subTree, selector).map((c) => createWrapper(c))
   }
 

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -20,8 +20,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
     vm: ComponentPublicInstance,
     setProps?: (props: Record<string, any>) => void
   ) {
-    // TODO Remove cast after Vue releases the fix
-    this.rootVM = (vm.$root as any) as ComponentPublicInstance
+    this.rootVM = vm.$root
     this.componentVM = vm as T
     this.__setProps = setProps
   }
@@ -111,10 +110,9 @@ export class VueWrapper<T extends ComponentPublicInstance>
 
   setProps(props: Record<string, any>): Promise<void> {
     // if this VM's parent is not the root, error out
-    // TODO: Remove ignore after Vue releases fix
-    // @ts-ignore
-    if (this.vm.$parent !== this.rootVM)
+    if (this.vm.$parent !== this.rootVM) {
       throw Error('You can only use setProps on your mounted component')
+    }
     this.__setProps(props)
     return nextTick()
   }

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -8,43 +8,36 @@ import {
   WrapperAPI
 } from './types'
 import { ErrorWrapper } from './error-wrapper'
-import { MOUNT_ELEMENT_ID } from './constants'
 import { find } from './utils/find'
 
 export class VueWrapper<T extends ComponentPublicInstance>
   implements WrapperAPI {
   private componentVM: T
-  private __emitted: Record<string, unknown[]> = {}
-  private __vm: ComponentPublicInstance
+  private rootVM: ComponentPublicInstance
   private __setProps: (props: Record<string, any>) => void
 
   constructor(
     vm: ComponentPublicInstance,
-    events: Record<string, unknown[]>,
-    setProps: (props: Record<string, any>) => void
+    setProps?: (props: Record<string, any>) => void
   ) {
-    this.__vm = vm
+    // TODO Remove cast after Vue releases the fix
+    this.rootVM = (vm.$root as any) as ComponentPublicInstance
+    this.componentVM = vm as T
     this.__setProps = setProps
-    this.componentVM = this.__vm.$refs['VTU_COMPONENT'] as T
-    this.__emitted = events
-  }
-
-  private get appRootNode() {
-    return document.getElementById(MOUNT_ELEMENT_ID) as HTMLDivElement
   }
 
   private get hasMultipleRoots(): boolean {
     // if the subtree is an array of children, we have multiple root nodes
-    return this.componentVM.$.subTree.shapeFlag === ShapeFlags.ARRAY_CHILDREN
+    return this.vm.$.subTree.shapeFlag === ShapeFlags.ARRAY_CHILDREN
   }
 
   private get parentElement(): Element {
-    return this.componentVM.$el.parentElement
+    return this.vm.$el.parentElement
   }
 
   get element(): Element {
     // if the component has multiple root elements, we use the parent's element
-    return this.hasMultipleRoots ? this.parentElement : this.componentVM.$el
+    return this.hasMultipleRoots ? this.parentElement : this.vm.$el
   }
 
   get vm(): T {
@@ -63,8 +56,10 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return true
   }
 
-  emitted() {
-    return this.__emitted
+  emitted(): Record<string, unknown[]> {
+    // TODO Should we define this?
+    // @ts-ignore
+    return this.vm.__emitted
   }
 
   html() {
@@ -94,18 +89,19 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return result
   }
 
-  findComponent(selector: FindComponentSelector): ComponentPublicInstance {
+  findComponent(selector: FindComponentSelector): VueWrapper | ErrorWrapper {
     if (typeof selector === 'object' && 'ref' in selector) {
-      return this.componentVM.$refs[selector.ref] as ComponentPublicInstance
+      return createWrapper(
+        this.vm.$refs[selector.ref] as ComponentPublicInstance
+      )
     }
-    const result = find(this.componentVM.$.subTree, selector)
-    return result.length ? result[0] : undefined
+    const result = find(this.vm.$.subTree, selector)
+    if (!result.length) return new ErrorWrapper({ selector })
+    return createWrapper(result[0])
   }
 
-  findAllComponents(
-    selector: FindAllComponentsSelector
-  ): ComponentPublicInstance[] {
-    return find(this.componentVM.$.subTree, selector)
+  findAllComponents(selector: FindAllComponentsSelector): VueWrapper[] {
+    return find(this.vm.$.subTree, selector).map((c) => createWrapper(c))
   }
 
   findAll<T extends Element>(selector: string): DOMWrapper<T>[] {
@@ -113,7 +109,12 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return Array.from(results).map((x) => new DOMWrapper(x))
   }
 
-  setProps(props: Record<string, any>) {
+  setProps(props: Record<string, any>): Promise<void> {
+    // if this VM's parent is not the root, error out
+    // TODO: Remove ignore after Vue releases fix
+    // @ts-ignore
+    if (this.vm.$parent !== this.rootVM)
+      throw Error('You can only use setProps on your mounted component')
     this.__setProps(props)
     return nextTick()
   }
@@ -126,8 +127,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
 
 export function createWrapper<T extends ComponentPublicInstance>(
   vm: ComponentPublicInstance,
-  events: Record<string, unknown[]>,
-  setProps: (props: Record<string, any>) => void
+  setProps?: (props: Record<string, any>) => void
 ): VueWrapper<T> {
-  return new VueWrapper<T>(vm, events, setProps)
+  return new VueWrapper<T>(vm, setProps)
 }

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -75,7 +75,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
   }
 
   html() {
-    return this.appRootNode.innerHTML
+    return this.parentElement.innerHTML
   }
 
   text() {
@@ -101,20 +101,22 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return result
   }
 
-  findComponent(selector: FindComponentSelector): any {
+  findComponent(selector: FindComponentSelector): ComponentPublicInstance {
     if (typeof selector === 'object' && 'ref' in selector) {
-      return this.componentVM.$refs[selector.ref]
+      return this.componentVM.$refs[selector.ref] as ComponentPublicInstance
     }
     const result = find(this.componentVM.$.subTree, selector)
-    return result.length ? result[0] : result
+    return result.length ? result[0] : undefined
   }
 
-  findAllComponents(selector: FindAllComponentsSelector): any[] {
+  findAllComponents(
+    selector: FindAllComponentsSelector
+  ): ComponentPublicInstance[] {
     return find(this.componentVM.$.subTree, selector)
   }
 
   findAll<T extends Element>(selector: string): DOMWrapper<T>[] {
-    const results = this.appRootNode.querySelectorAll<T>(selector)
+    const results = this.parentElement.querySelectorAll<T>(selector)
     return Array.from(results).map((x) => new DOMWrapper(x))
   }
 

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -7,6 +7,17 @@ import { ErrorWrapper } from './error-wrapper'
 import { MOUNT_ELEMENT_ID } from './constants'
 import { find } from './utils/find'
 
+interface RefSelector {
+  ref: string
+}
+
+interface NameSelector {
+  name: string
+}
+
+type FindComponentSelector = RefSelector | NameSelector | string
+type FindAllComponentsSelector = NameSelector | string
+
 export class VueWrapper<T extends ComponentPublicInstance>
   implements WrapperAPI {
   private componentVM: T
@@ -90,10 +101,15 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return result
   }
 
-  findByComponent(selector: { ref?: string; name?: string } | string): any {
-    if (typeof selector === 'object' && selector.ref) {
+  findComponent(selector: FindComponentSelector): any {
+    if (typeof selector === 'object' && 'ref' in selector) {
       return this.componentVM.$refs[selector.ref]
     }
+    const result = find(this.componentVM.$.subTree, selector)
+    return result.length ? result[0] : result
+  }
+
+  findAllComponents(selector: FindAllComponentsSelector): any[] {
     return find(this.componentVM.$.subTree, selector)
   }
 

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -5,6 +5,7 @@ import { DOMWrapper } from './dom-wrapper'
 import { WrapperAPI } from './types'
 import { ErrorWrapper } from './error-wrapper'
 import { MOUNT_ELEMENT_ID } from './constants'
+import { find } from './utils/find'
 
 export class VueWrapper<T extends ComponentPublicInstance>
   implements WrapperAPI {
@@ -87,6 +88,13 @@ export class VueWrapper<T extends ComponentPublicInstance>
     }
 
     return result
+  }
+
+  findByComponent(selector: { ref?: string; name?: string } | string): any {
+    if (typeof selector === 'object' && selector.ref) {
+      return this.componentVM.$refs[selector.ref]
+    }
+    return find(this.componentVM.$.subTree, selector)
   }
 
   findAll<T extends Element>(selector: string): DOMWrapper<T>[] {

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -2,21 +2,14 @@ import { ComponentPublicInstance, nextTick } from 'vue'
 import { ShapeFlags } from '@vue/shared'
 
 import { DOMWrapper } from './dom-wrapper'
-import { WrapperAPI } from './types'
+import {
+  FindAllComponentsSelector,
+  FindComponentSelector,
+  WrapperAPI
+} from './types'
 import { ErrorWrapper } from './error-wrapper'
 import { MOUNT_ELEMENT_ID } from './constants'
 import { find } from './utils/find'
-
-interface RefSelector {
-  ref: string
-}
-
-interface NameSelector {
-  name: string
-}
-
-type FindComponentSelector = RefSelector | NameSelector | string
-type FindAllComponentsSelector = NameSelector | string
 
 export class VueWrapper<T extends ComponentPublicInstance>
   implements WrapperAPI {

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -44,28 +44,6 @@ describe('find', () => {
     expect(wrapper.html()).toContain('Fallback content')
     expect(wrapper.find('div').exists()).toBeTruthy()
   })
-
-  it('finds deeply nested vue components', () => {
-    const compC = {
-      template: '<div class="C">C</div>'
-    }
-    const compB = {
-      template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
-      components: { compC }
-    }
-    const compA = {
-      template: '<div class="A"><comp-b/><hello ref="b"/></div>',
-      components: { compB, Hello }
-    }
-    const wrapper = mount(compA)
-    // find by ref
-    expect(wrapper.findByComponent({ ref: 'b' })).toBeTruthy()
-    // find by DOM selector
-    expect(wrapper.findByComponent('.C').el.textContent).toEqual('C')
-    expect(wrapper.findByComponent({ name: 'Hello' }).el.textContent).toBe(
-      'Hello world'
-    )
-  })
 })
 
 describe('findAll', () => {

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -2,6 +2,7 @@ import { defineComponent, h } from 'vue'
 
 import { mount } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
+import Hello from './components/Hello.vue'
 
 describe('find', () => {
   it('find using single root node', () => {
@@ -42,6 +43,28 @@ describe('find', () => {
 
     expect(wrapper.html()).toContain('Fallback content')
     expect(wrapper.find('div').exists()).toBeTruthy()
+  })
+
+  it('finds deeply nested vue components', () => {
+    const compC = {
+      template: '<div class="C">C</div>'
+    }
+    const compB = {
+      template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+      components: { compC }
+    }
+    const compA = {
+      template: '<div class="A"><comp-b/><hello ref="b"/></div>',
+      components: { compB, Hello }
+    }
+    const wrapper = mount(compA)
+    // find by ref
+    expect(wrapper.findByComponent({ ref: 'b' })).toBeTruthy()
+    // find by DOM selector
+    expect(wrapper.findByComponent('.C').el.textContent).toEqual('C')
+    expect(wrapper.findByComponent({ name: 'Hello' }).el.textContent).toBe(
+      'Hello world'
+    )
   })
 })
 

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -1,18 +1,19 @@
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
+import { defineComponent } from 'vue'
 
-const compC = {
+const compC = defineComponent({
   name: 'ComponentC',
   template: '<div class="C">C</div>'
-}
-const compB = {
+})
+const compB = defineComponent({
   template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
   components: { compC }
-}
-const compA = {
+})
+const compA = defineComponent({
   template: '<div class="A"><comp-b ref="b"/><hello ref="b"/></div>',
   components: { compB, Hello }
-}
+})
 
 describe('findAllComponents', () => {
   it('finds all deeply nested vue components', () => {

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -19,11 +19,9 @@ describe('findAllComponents', () => {
     const wrapper = mount(compA)
     // find by DOM selector
     expect(wrapper.findAllComponents('.C')).toHaveLength(2)
-    expect(
-      wrapper.findAllComponents({ name: 'Hello' })[0].$el.textContent
-    ).toBe('Hello world')
-    expect(wrapper.findAllComponents(Hello)[0].$el.textContent).toBe(
+    expect(wrapper.findAllComponents({ name: 'Hello' })[0].text()).toBe(
       'Hello world'
     )
+    expect(wrapper.findAllComponents(Hello)[0].text()).toBe('Hello world')
   })
 })

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '../src'
+import Hello from './components/Hello.vue'
+
+const compC = {
+  name: 'ComponentC',
+  template: '<div class="C">C</div>'
+}
+const compB = {
+  template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+  components: { compC }
+}
+const compA = {
+  template: '<div class="A"><comp-b ref="b"/><hello ref="b"/></div>',
+  components: { compB, Hello }
+}
+
+describe('findAllComponents', () => {
+  it('finds all deeply nested vue components', () => {
+    const wrapper = mount(compA)
+    // find by DOM selector
+    expect(wrapper.findAllComponents('.C')).toHaveLength(2)
+    expect(wrapper.findAllComponents({ name: 'Hello' })[0].el.textContent).toBe(
+      'Hello world'
+    )
+    expect(wrapper.findAllComponents(Hello)[0].el.textContent).toBe(
+      'Hello world'
+    )
+  })
+})

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -19,10 +19,10 @@ describe('findAllComponents', () => {
     const wrapper = mount(compA)
     // find by DOM selector
     expect(wrapper.findAllComponents('.C')).toHaveLength(2)
-    expect(wrapper.findAllComponents({ name: 'Hello' })[0].el.textContent).toBe(
-      'Hello world'
-    )
-    expect(wrapper.findAllComponents(Hello)[0].el.textContent).toBe(
+    expect(
+      wrapper.findAllComponents({ name: 'Hello' })[0].$el.textContent
+    ).toBe('Hello world')
+    expect(wrapper.findAllComponents(Hello)[0].$el.textContent).toBe(
       'Hello world'
     )
   })

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -1,0 +1,28 @@
+import { mount } from '../src'
+import Hello from './components/Hello.vue'
+
+describe('findComponent', () => {
+  it('finds deeply nested vue components', () => {
+    const compC = {
+      name: 'ComponentC',
+      template: '<div class="C">C</div>'
+    }
+    const compB = {
+      template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+      components: { compC }
+    }
+    const compA = {
+      template: '<div class="A"><comp-b/><hello ref="b"/></div>',
+      components: { compB, Hello }
+    }
+    const wrapper = mount(compA)
+    // find by ref
+    expect(wrapper.findComponent({ ref: 'b' })).toBeTruthy()
+    // find by DOM selector
+    expect(wrapper.findComponent('.C').type.name).toEqual('ComponentC')
+    expect(wrapper.findComponent({ name: 'Hello' }).el.textContent).toBe(
+      'Hello world'
+    )
+    expect(wrapper.findComponent(Hello).el.textContent).toBe('Hello world')
+  })
+})

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -19,10 +19,10 @@ describe('findComponent', () => {
     // find by ref
     expect(wrapper.findComponent({ ref: 'b' })).toBeTruthy()
     // find by DOM selector
-    expect(wrapper.findComponent('.C').type.name).toEqual('ComponentC')
-    expect(wrapper.findComponent({ name: 'Hello' }).el.textContent).toBe(
+    expect(wrapper.findComponent('.C').$options.name).toEqual('ComponentC')
+    expect(wrapper.findComponent({ name: 'Hello' }).$el.textContent).toBe(
       'Hello world'
     )
-    expect(wrapper.findComponent(Hello).el.textContent).toBe('Hello world')
+    expect(wrapper.findComponent(Hello).$el.textContent).toBe('Hello world')
   })
 })

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -37,7 +37,7 @@ const compA = {
 describe('findComponent', () => {
   it('does not find plain dom elements', () => {
     const wrapper = mount(compA)
-    expect(wrapper.findComponent('.domElement')).toBeFalsy()
+    expect(wrapper.findComponent('.domElement').exists()).toBeFalsy()
   })
 
   it('finds component by ref', () => {
@@ -49,34 +49,39 @@ describe('findComponent', () => {
   it('finds component by dom selector', () => {
     const wrapper = mount(compA)
     // find by DOM selector
-    expect(wrapper.findComponent('.C').$options.name).toEqual('ComponentC')
+    expect(wrapper.findComponent('.C').vm).toHaveProperty(
+      '$options.name',
+      'ComponentC'
+    )
   })
 
   it('does allows using complicated DOM selector query', () => {
     const wrapper = mount(compA)
-    expect(wrapper.findComponent('.B > .C').$options.name).toEqual('ComponentC')
+    expect(wrapper.findComponent('.B > .C').vm).toHaveProperty(
+      '$options.name',
+      'ComponentC'
+    )
   })
 
   it('finds a component when root of mounted component', async () => {
     const wrapper = mount(compD)
     // make sure it finds the component, not its root
-    expect(wrapper.findComponent('.c-as-root-on-d').$options.name).toEqual(
+    expect(wrapper.findComponent('.c-as-root-on-d').vm).toHaveProperty(
+      '$options.name',
       'ComponentC'
     )
   })
 
   it('finds component by name', () => {
     const wrapper = mount(compA)
-    expect(wrapper.findComponent({ name: 'Hello' }).$el.textContent).toBe(
-      'Hello world'
-    )
-    expect(wrapper.findComponent({ name: 'ComponentB' })).toBeTruthy()
-    expect(wrapper.findComponent({ name: 'component-c' })).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'Hello' }).text()).toBe('Hello world')
+    expect(wrapper.findComponent({ name: 'ComponentB' }).exists()).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'component-c' }).exists()).toBeTruthy()
   })
 
   it('finds component by imported SFC file', () => {
     const wrapper = mount(compA)
-    expect(wrapper.findComponent(Hello).$el.textContent).toBe('Hello world')
-    expect(wrapper.findComponent(compC).$el.textContent).toBe('C')
+    expect(wrapper.findComponent(Hello).text()).toBe('Hello world')
+    expect(wrapper.findComponent(compC).text()).toBe('C')
   })
 })

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -5,17 +5,41 @@ const compC = {
   name: 'ComponentC',
   template: '<div class="C">C</div>'
 }
-const compB = {
-  name: 'component-b',
-  template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+
+const compD = {
+  name: 'ComponentD',
+  template: '<comp-c class="c-as-root-on-d" />',
   components: { compC }
 }
+
+const compB = {
+  name: 'component-b',
+  template: `
+    <div class="B">
+      TextBefore
+      <comp-c />
+      TextAfter
+      <comp-c />
+      <comp-d id="compD" />
+    </div>`,
+  components: { compC, compD }
+}
 const compA = {
-  template: '<div class="A"><comp-b/><hello ref="b"/></div>',
+  template: `
+    <div class="A">
+      <comp-b />
+      <hello ref="b" />
+      <div class="domElement" />
+    </div>`,
   components: { compB, Hello }
 }
 
 describe('findComponent', () => {
+  it('does not find plain dom elements', () => {
+    const wrapper = mount(compA)
+    expect(wrapper.findComponent('.domElement')).toBeFalsy()
+  })
+
   it('finds component by ref', () => {
     const wrapper = mount(compA)
     // find by ref
@@ -26,6 +50,19 @@ describe('findComponent', () => {
     const wrapper = mount(compA)
     // find by DOM selector
     expect(wrapper.findComponent('.C').$options.name).toEqual('ComponentC')
+  })
+
+  it('does allows using complicated DOM selector query', () => {
+    const wrapper = mount(compA)
+    expect(wrapper.findComponent('.B > .C').$options.name).toEqual('ComponentC')
+  })
+
+  it('finds a component when root of mounted component', async () => {
+    const wrapper = mount(compD)
+    // make sure it finds the component, not its root
+    expect(wrapper.findComponent('.c-as-root-on-d').$options.name).toEqual(
+      'ComponentC'
+    )
   })
 
   it('finds component by name', () => {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -1,28 +1,45 @@
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 
+const compC = {
+  name: 'ComponentC',
+  template: '<div class="C">C</div>'
+}
+const compB = {
+  name: 'component-b',
+  template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+  components: { compC }
+}
+const compA = {
+  template: '<div class="A"><comp-b/><hello ref="b"/></div>',
+  components: { compB, Hello }
+}
+
 describe('findComponent', () => {
-  it('finds deeply nested vue components', () => {
-    const compC = {
-      name: 'ComponentC',
-      template: '<div class="C">C</div>'
-    }
-    const compB = {
-      template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
-      components: { compC }
-    }
-    const compA = {
-      template: '<div class="A"><comp-b/><hello ref="b"/></div>',
-      components: { compB, Hello }
-    }
+  it('finds component by ref', () => {
     const wrapper = mount(compA)
     // find by ref
     expect(wrapper.findComponent({ ref: 'b' })).toBeTruthy()
+  })
+
+  it('finds component by dom selector', () => {
+    const wrapper = mount(compA)
     // find by DOM selector
     expect(wrapper.findComponent('.C').$options.name).toEqual('ComponentC')
+  })
+
+  it('finds component by name', () => {
+    const wrapper = mount(compA)
     expect(wrapper.findComponent({ name: 'Hello' }).$el.textContent).toBe(
       'Hello world'
     )
+    expect(wrapper.findComponent({ name: 'ComponentB' })).toBeTruthy()
+    expect(wrapper.findComponent({ name: 'component-c' })).toBeTruthy()
+  })
+
+  it('finds component by imported SFC file', () => {
+    const wrapper = mount(compA)
     expect(wrapper.findComponent(Hello).$el.textContent).toBe('Hello world')
+    expect(wrapper.findComponent(compC).$el.textContent).toBe('C')
   })
 })

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -1,18 +1,19 @@
+import { defineComponent } from 'vue'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 
-const compC = {
+const compC = defineComponent({
   name: 'ComponentC',
   template: '<div class="C">C</div>'
-}
+})
 
-const compD = {
+const compD = defineComponent({
   name: 'ComponentD',
   template: '<comp-c class="c-as-root-on-d" />',
   components: { compC }
-}
+})
 
-const compB = {
+const compB = defineComponent({
   name: 'component-b',
   template: `
     <div class="B">
@@ -23,8 +24,9 @@ const compB = {
       <comp-d id="compD" />
     </div>`,
   components: { compC, compD }
-}
-const compA = {
+})
+
+const compA = defineComponent({
   template: `
     <div class="A">
       <comp-b />
@@ -32,7 +34,7 @@ const compA = {
       <div class="domElement" />
     </div>`,
   components: { compB, Hello }
-}
+})
 
 describe('findComponent', () => {
   it('does not find plain dom elements', () => {

--- a/tests/setProps.spec.ts
+++ b/tests/setProps.spec.ts
@@ -10,10 +10,10 @@ describe('setProps', () => {
     }
     const wrapper = mount(Foo, {
       props: {
-        foo: 'foo'
+        foo: 'bar'
       }
     })
-    expect(wrapper.html()).toContain('foo')
+    expect(wrapper.html()).toContain('bar')
 
     await wrapper.setProps({ foo: 'qux' })
     expect(wrapper.html()).toContain('qux')
@@ -44,7 +44,8 @@ describe('setProps', () => {
   it('sets component props, and updates DOM when props were not initially passed', async () => {
     const Foo = {
       props: ['foo'],
-      template: `<div>{{ foo }}</div>`
+      template: `
+        <div>{{ foo }}</div>`
     }
     const wrapper = mount(Foo)
     expect(wrapper.html()).not.toContain('foo')
@@ -67,7 +68,8 @@ describe('setProps', () => {
           this.bar = val
         }
       },
-      template: `<div>{{ bar }}</div>`
+      template: `
+        <div>{{ bar }}</div>`
     }
     const wrapper = mount(Foo)
     expect(wrapper.html()).toContain('original-bar')
@@ -117,5 +119,28 @@ describe('setProps', () => {
 
     expect(wrapper.attributes()).toEqual(nonExistentProp)
     expect(wrapper.html()).toBe('<div bar="qux">foo</div>')
+  })
+
+  it('allows using only on mounted component', async () => {
+    const Foo = {
+      name: 'Foo',
+      props: ['foo'],
+      template: '<div>{{ foo }}</div>'
+    }
+    const Baz = {
+      props: ['baz'],
+      template: '<div><Foo :foo="baz"/></div>',
+      components: { Foo }
+    }
+
+    const wrapper = mount(Baz, {
+      props: {
+        baz: 'baz'
+      }
+    })
+    const FooResult = wrapper.findComponent({ name: 'Foo' })
+    expect(() => FooResult.setProps({ baz: 'bin' })).toThrowError(
+      'You can only use setProps on your mounted component'
+    )
   })
 })

--- a/tests/vm.spec.ts
+++ b/tests/vm.spec.ts
@@ -5,6 +5,7 @@ import { mount } from '../src'
 describe('vm', () => {
   it('returns the component vm', () => {
     const Component = defineComponent({
+      name: 'VTUComponent',
       template: '<div>{{ msg }}</div>',
       setup() {
         const msg = 'hello'

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,10 +268,10 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
-  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -830,7 +830,16 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.8.6", "@babel/types@^7.9.0":
+"@babel/types@^7.8.6":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
@@ -1951,9 +1960,9 @@ cssstyle@^2.0.0:
     cssom "~0.3.6"
 
 csstype@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
-  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
This PR allows finding a Vue Component and returning a new VueWrapper with it's instance.

## Caveats:

* Returns only Vue components, and works only on VueWrapper. 
* You cant chain it from a DOMWrapper 
* setProps does not work on newly wrapped instances, from FindComponent. (which is fine)

## Reasoning behind this

Many codebases use Components, Ref or Name  to search for Vue instances, when doing tricky assertions, or mounting shallow.