### PR TITLE
Bump Vue to beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/estree": "^0.0.42",
     "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.149",
-    "@vue/compiler-sfc": "^3.0.0-alpha.13",
+    "@vue/compiler-sfc": "^3.0.0-beta.1",
     "babel-jest": "^25.2.3",
     "babel-preset-jest": "^25.2.1",
     "flush-promises": "^1.0.2",
@@ -34,7 +34,7 @@
     "rollup-plugin-typescript2": "^0.26.0",
     "ts-jest": "^25.0.0",
     "typescript": "^3.7.5",
-    "vue": "^3.0.0-alpha.13",
+    "vue": "^3.0.0-beta.1",
     "vue-jest": "vuejs/vue-jest#next",
     "vuex": "^4.0.0-alpha.1"
   },

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -108,7 +108,11 @@ export function mount<T extends ComponentPublicInstance>(
     const mixin = {
       beforeCreate() {
         for (const [k, v] of Object.entries(options.global?.mocks)) {
-          this[k] = v
+          if (!vm.config.globalProperties[k]) {
+            Object.defineProperty(vm.config.globalProperties, k, {
+              get: () => v
+            })
+          }
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,10 +268,10 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
-  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -830,7 +830,16 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.8.6", "@babel/types@^7.9.0":
+"@babel/types@^7.8.6":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
@@ -1222,34 +1231,34 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vue/compiler-core@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-alpha.13.tgz#8126c92f562af047c28c4ce7f343d77f0ceea7d7"
-  integrity sha512-k7VTQnjQlCfsSdfwi867dUHUzqm5/2qldikWAABMlaqr4mEn+yVCla7JqQxFGZta/JF8cOv/GfqlA/vWBlYh7A==
+"@vue/compiler-core@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.1.tgz#77017e0a98b808da3834327bcf8857e4b89363ef"
+  integrity sha512-mlHfX/+3qH+GAuMbGFvye0Jn2/H9IwbmX6oqbpLErM241xAVbpqniFDiJCywrfjeUDKMfDuNs1i6lGnDBH715g==
   dependencies:
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/shared" "3.0.0-beta.1"
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-alpha.13.tgz#b1930ebbe770dbed543dbe7ac88f2955719051f2"
-  integrity sha512-g5FnVAx+HLUox3N+XHKIZTpMJeJu5Uj0JNf8X4s5Td5zFcWG+KJGUHz8qU9H0unrPc01uiT/VfhYErhFcRdVKg==
+"@vue/compiler-dom@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.1.tgz#eabd8279e5433214e613558561f59e05a01ef450"
+  integrity sha512-Tp3Y2sT014B0Z3VpdWLwAv8o6kNPZOwFFMI2aAgIBmG3KWPGXUxm2LDRrNZWPoOPYPWYjRMBri1cNy3gA2MeCA==
   dependencies:
-    "@vue/compiler-core" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/compiler-core" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
 
-"@vue/compiler-sfc@^3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-alpha.13.tgz#075921331a01ab483e71e3b33bf4238c0c35a449"
-  integrity sha512-koU+iNgyleTBRphI/XZ4V1UxveQC4ILniOXFVRNTHBCzSzfFI+Dd5lHMr3BDOABnb1EuUZeC/hAz6tc4U0qzEw==
+"@vue/compiler-sfc@^3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.1.tgz#1d1ae5e2d2ba83f5234d4b2f84e4ba4bd5741c27"
+  integrity sha512-Dv+cKKGMwGOpDzE9UuWe/jCerIdDxwd0CAtxgF2XrXULxNeHGSedmx7m2fkPLSKqqDfHtbPZuU55jWp4axL6wA==
   dependencies:
-    "@vue/compiler-core" "3.0.0-alpha.13"
-    "@vue/compiler-dom" "3.0.0-alpha.13"
-    "@vue/compiler-ssr" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/compiler-core" "3.0.0-beta.1"
+    "@vue/compiler-dom" "3.0.0-beta.1"
+    "@vue/compiler-ssr" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
     consolidate "^0.15.1"
     hash-sum "^2.0.0"
     lru-cache "^5.1.1"
@@ -1258,42 +1267,42 @@
     postcss-selector-parser "^6.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-ssr@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-alpha.13.tgz#9d8955b1af20c819bc2e4c336d4987ce36f92f15"
-  integrity sha512-K3+PQKKQGQNdlqLpAah7s5jRlE5sDCkhc54PM7XK7F9yjyzWFWApaMEZjJrqYWjjYFgLkTXzgd8CdV72vMy7HQ==
+"@vue/compiler-ssr@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.1.tgz#e0cfde96de4d41809d59102e7f1f0f860e731cde"
+  integrity sha512-vO4r0/P3G/LfLgJGKrMh9MD1wExCajrAE5nNlqAkWduIYY+4fegF7UyO67dU+ji1YShxrPfDYJ8vcSb4XTKXxQ==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/compiler-dom" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
 
-"@vue/reactivity@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-alpha.13.tgz#032fbfd1b9c50153e2f37fc99ae63b460377387a"
-  integrity sha512-ICzFWsxQAyPDW8O9SGJ++tYXRHOUBTh1/qKZsIEOTQEI1Rt0O9EOOXA3NGlGmSS2U0EXO0Usfcvn9EoHRwFBHw==
+"@vue/reactivity@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.1.tgz#b4899fe95efbc8ed15343f9d67950f2a33e219dc"
+  integrity sha512-XbitRfUKIAgPO0IXEbi9/mq93xOL5CGRjaTPH2DvvTU0hXlAeW8aMPQe3+R+vvXppBiFERY3yjZjQc5SYkZVsg==
   dependencies:
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/shared" "3.0.0-beta.1"
 
-"@vue/runtime-core@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-alpha.13.tgz#2430fc835399924c206d113e6f6acaa921707a3f"
-  integrity sha512-bo6hQQN0qfo7zWaSdegTa2eU7yXEK4v3noLyHmWhCbIzrKPa0pauGU1nBnXOlTgM8bkL8i8+rvMB0YwEJkhLMw==
+"@vue/runtime-core@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.1.tgz#a3d97183dd5bc022fc02b9a86180698dc11a2e65"
+  integrity sha512-eNHHGT17i2dOtAQpmn8QRDAcVGS4TiCyjGW+v6GfSlHvip1fFUmawD9pLSPVdL3DngGm9SmioOVmBK2CB8JG0g==
   dependencies:
-    "@vue/reactivity" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/reactivity" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
 
-"@vue/runtime-dom@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-alpha.13.tgz#de33f7ae9035877ede1bee27e5c28108f1eea86a"
-  integrity sha512-fnz1QZhLxodrDFSvtTwP84xGo6yrzEoC1k7LFh0mnOu6Mw3r4WkVhD8xeh3A/oPJ3jM22cIe8SL5UJqLeltQyw==
+"@vue/runtime-dom@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.1.tgz#f93565cccdc0a1d2f419836d5468989a7a868c66"
+  integrity sha512-+dnJS7582V6iZLm8YqsXjabL1eXo3n8ltzxWZlI/nV1ZPSWKQJpvB6ICbdRjwOlka4lukYStca3ZsrYQI7SvVg==
   dependencies:
-    "@vue/runtime-core" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/runtime-core" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
     csstype "^2.6.8"
 
-"@vue/shared@3.0.0-alpha.13":
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-alpha.13.tgz#7d9bcf763c77bd9e10bbb6a27577af7f0ad853c4"
-  integrity sha512-j3co+5x0DNZXQzS3drvWaRwQVFltkY4fQHdegfVIofhXZc/PrHP4E+PE3U8GxeqrU6DSjO+4YpY4aVGRUjbgpw==
+"@vue/shared@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.1.tgz#234185d345cde7e05db569e653feae87912bf218"
+  integrity sha512-LehYUPtykdL3ZEUto2W1n26k+opBT1gtFdESPtp4lGo9oIreLl3pJVoUPIkY/Kk/mOZGmBOsYXiLZGJvfmGEQw==
 
 abab@^2.0.0:
   version "2.0.3"
@@ -1951,9 +1960,9 @@ cssstyle@^2.0.0:
     cssom "~0.3.6"
 
 csstype@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
-  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -5110,14 +5119,14 @@ vue-jest@vuejs/vue-jest#next:
     extract-from-css "^0.4.4"
     ts-jest "^24.0.0"
 
-vue@^3.0.0-alpha.13:
-  version "3.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-alpha.13.tgz#a0428ec5494841f2f3564b47a17c550645b8f442"
-  integrity sha512-U7Lq60IJojWAUqn7n43F0TqfcQdjYOgQ2OTQuz7wvcfStJ+LxNFOd8/qX5MuJCG/f/7gmOMda1+U/CEa6NEEIg==
+vue@^3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.1.tgz#86a4b8431ab4b7523487cad4ec0d7235fead22dc"
+  integrity sha512-Z5SFtxSQNYwtyfMWxAiJYoumOwRnRdha6opDaRy8f4jhJAGn9tpi2muJLxE4m6QZ9UqjnHghUC3VjxzXfofQTQ==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-alpha.13"
-    "@vue/runtime-dom" "3.0.0-alpha.13"
-    "@vue/shared" "3.0.0-alpha.13"
+    "@vue/compiler-dom" "3.0.0-beta.1"
+    "@vue/runtime-dom" "3.0.0-beta.1"
+    "@vue/shared" "3.0.0-beta.1"
 
 vuex@^4.0.0-alpha.1:
   version "4.0.0-alpha.1"


### PR DESCRIPTION
Looks like it has some breaking changes that are affecting us.

https://github.com/vuejs/vue-next/blob/master/CHANGELOG.md#300-beta1-2020-04-16

https://github.com/vuejs/vue-next/compare/v3.0.0-alpha.13...v3.0.0-beta.1
