### PR TITLE
fix: remove globalProperties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,20 +10,24 @@ const pascalCase = flow(camelCase, upperFirst)
 export { kebabCase, pascalCase }
 
 export function mergeGlobalProperties(
-  configGlobal = {},
-  mountGlobal = {}
+  configGlobal: GlobalMountOptions = {},
+  mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
-  return mergeWith({}, configGlobal, mountGlobal, (objValue, srcValue, key) => {
-    switch (key) {
-      case 'mocks':
-      case 'provide':
-      case 'components':
-      case 'directives':
-      case 'globalProperties':
-        return { ...objValue, ...srcValue }
-      case 'plugins':
-      case 'mixins':
-        return [...(objValue || []), ...(srcValue || [])].filter(Boolean)
+  return mergeWith(
+    {},
+    configGlobal,
+    mountGlobal,
+    (objValue, srcValue, key: keyof GlobalMountOptions) => {
+      switch (key) {
+        case 'mocks':
+        case 'provide':
+        case 'components':
+        case 'directives':
+          return { ...objValue, ...srcValue }
+        case 'plugins':
+        case 'mixins':
+          return [...(objValue || []), ...(srcValue || [])].filter(Boolean)
+      }
     }
-  })
+  )
 }


### PR DESCRIPTION
Fixes something I spotted after #53 was merged

`globalProperties` is not supported AFAIK and was removed from the original PR except in the `mergeGlobalProperties` utils.
With the various parameters correctly typed, the code was throwing a compilation error as TS can spot that `globalProperties` is not a key of `GlobalMountOptions`.