### PR TITLE
fix: emit should propagate the event

### DIFF
--- a/src/emitMixin.ts
+++ b/src/emitMixin.ts
@@ -5,12 +5,12 @@ export const attachEmitListener = () => {
     beforeCreate() {
       let events: Record<string, unknown[]> = {}
       this.__emitted = events
-
+      const originalEmit = getCurrentInstance().emit
       getCurrentInstance().emit = (event: string, ...args: unknown[]) => {
         events[event]
           ? (events[event] = [...events[event], [...args]])
           : (events[event] = [[...args]])
-
+        originalEmit(event, ...args)
         return [event, ...args]
       }
     }

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -65,4 +65,35 @@ describe('emitted', () => {
     wrapper.find('button').trigger('click')
     expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
   })
+
+  it('should propagate the original event', () => {
+    const Component = defineComponent({
+      name: 'ContextEmit',
+
+      setup(props, { emit }) {
+        return () =>
+          h('div', [
+            h('button', { onClick: () => emit('hello', 'foo', 'bar') })
+          ])
+      }
+    })
+
+    const Parent = defineComponent({
+      name: 'Parent',
+
+      setup(props, { emit }) {
+        return () =>
+          h(Component, { onHello: (...events) => emit('parent', ...events) })
+      }
+    })
+    const wrapper = mount(Parent)
+    expect(wrapper.emitted()).toEqual({})
+    expect(wrapper.emitted().hello).toEqual(undefined)
+
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().parent[0]).toEqual(['foo', 'bar'])
+
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().parent[1]).toEqual(['foo', 'bar'])
+  })
 })


### PR DESCRIPTION
This commit fixes an issue where emit is replaced but does not does its job, so a component emitting an event never really emits it, and a parent component never receives it.
The unit test added reproduces the issue.