### PR TITLE
repro: setProps breaks reactivity

### DIFF
--- a/tests/setProps.spec.ts
+++ b/tests/setProps.spec.ts
@@ -102,6 +102,30 @@ describe('setProps', () => {
     expect(wrapper.html()).toContain('Foo is: qux. Foobar is: qux-bar')
   })
 
+  it('does not break reactivity', async () => {
+    const useFoobar = (foo) => computed(() => `${foo}-bar`)
+    const Foo = defineComponent({
+      props: {
+        foo: { type: String }
+      },
+      setup(props) {
+        const foobar = useFoobar(props.foo)
+        return () =>
+          h('div', `Foo is: ${props.foo}. Foobar is: ${foobar.value}`)
+      }
+    })
+    const wrapper = mount(Foo, {
+      props: {
+        foo: 'foo'
+      }
+    })
+    expect(wrapper.html()).toContain('Foo is: foo. Foobar is: foo-bar')
+
+    await wrapper.setProps({ foo: 'qux' })
+
+    expect(wrapper.html()).toContain('Foo is: qux. Foobar is: qux-bar')
+  })
+
   it('non-existent props are rendered as attributes', async () => {
     const Foo = {
       props: ['foo'],


### PR DESCRIPTION
This adds a failing unit-test to showcase how `setProps` can break reactivity.
The example works fine in an application, but can't be unit tested with the current `setProps`, so I think this is an issue no?