### PR TITLE
repro: findComponent fails inside a Suspense

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -46,8 +46,12 @@ function findAllVNodes(vnode: VNode, selector: any): VNode[] {
   const nodes = [vnode]
   while (nodes.length) {
     const node = nodes.shift()
+    // match direct children
     aggregateChildren(nodes, node.children)
+    // match children of the wrapping component
     aggregateChildren(nodes, node.component?.subTree.children)
+    // match children if component is Suspense
+    aggregateChildren(nodes, node.suspense?.subTree.children)
     if (matches(node, selector)) {
       matchingNodes.push(node)
     }

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -2,7 +2,6 @@ import { defineComponent, h } from 'vue'
 
 import { mount } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
-import Hello from './components/Hello.vue'
 
 describe('find', () => {
   it('find using single root node', () => {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 import ComponentWithoutName from './components/ComponentWithoutName.vue'
@@ -110,6 +110,30 @@ describe('findComponent', () => {
     const wrapper = mount(compA)
     expect(wrapper.findComponent(Hello).text()).toBe('Hello world')
     expect(wrapper.findComponent(compC).text()).toBe('C')
+  })
+
+  it('finds component in a Suspense', async () => {
+    const AsyncComponent = defineComponent({
+      template: '{{ result }}',
+      async setup() {
+        return { result: 'Hello world' }
+      }
+    })
+    const SuspenseComponent = defineComponent({
+      template: `<Suspense>
+        <template #default><AsyncComponent/></template>
+        <template #fallback>Loading...</template>
+      </Suspense>`,
+      components: {
+        AsyncComponent
+      }
+    })
+    const wrapper = mount(SuspenseComponent)
+    expect(wrapper.html()).toContain('Loading')
+    await nextTick()
+    await nextTick()
+    expect(wrapper.html()).toContain('Hello world')
+    expect(wrapper.findComponent(AsyncComponent).text()).toBe('Hello world')
   })
 
   it('finds a stub by name', () => {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -112,6 +112,27 @@ describe('findComponent', () => {
     expect(wrapper.findComponent(compC).text()).toBe('C')
   })
 
+  it('finds component in a portal', async () => {
+    const Foo = {
+      name: 'Foo',
+      template: '<div>Foo</div>'
+    }
+
+    const Comp = defineComponent({
+      components: { Foo },
+      template: `
+        <div id="dest"></div>
+        <Teleport to="#dest">
+          <Foo />
+        </Teleport>
+      `
+    })
+    const wrapper = mount(Comp)
+
+    expect(wrapper.find('#dest').text()).toContain('Foo')
+    expect(wrapper.findComponent({ name: 'Foo' }).text()).toContain('Foo')
+  })
+
   it('finds component in a Suspense', async () => {
     const AsyncComponent = defineComponent({
       template: '{{ result }}',


### PR DESCRIPTION
This adds a failing unit-test to showcase how `findComponent` fails if the search component is inside a `Suspense`.
I was naively expecting it to work, do you think we should support this?