### PR TITLE
fix: improve error message for getComponent

### DIFF
--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -148,9 +148,18 @@ export class VueWrapper<T extends ComponentPublicInstance>
   ): VueWrapper<T> {
     const result = this.findComponent(selector)
     if (result instanceof ErrorWrapper) {
-      throw new Error(
-        `Unable to get component with selector ${selector} within: ${this.html()}`
-      )
+      let message = 'Unable to get '
+      if (typeof selector === 'string') {
+        message += `component with selector ${selector}`
+      } else if (selector.name) {
+        message += `component with name ${selector.name}`
+      } else if (selector.ref) {
+        message += `component with ref ${selector.ref}`
+      } else {
+        message += 'specified component'
+      }
+      message += ` within: ${this.html()}`
+      throw new Error(message)
     }
 
     return result as VueWrapper<T>

--- a/tests/getComponent.spec.ts
+++ b/tests/getComponent.spec.ts
@@ -1,8 +1,12 @@
 import { defineComponent } from 'vue'
 import { mount } from '../src'
-import { VueWrapper } from '../src/vue-wrapper'
 
 const compA = defineComponent({
+  template: `<div class="A"></div>`
+})
+
+const compB = defineComponent({
+  name: 'CompB',
   template: `<div class="A"></div>`
 })
 
@@ -14,10 +18,38 @@ describe('getComponent', () => {
     expect(wrapper.findComponent).toHaveBeenCalledWith('.domElement')
   })
 
-  it('should throw if not found', () => {
+  it('should throw if not found with a string selector', () => {
     const wrapper = mount(compA)
     expect(() => wrapper.getComponent('.domElement')).toThrowError(
       'Unable to get component with selector .domElement within: <div class="A"></div>'
+    )
+  })
+
+  it('should throw if not found with a name selector', () => {
+    const wrapper = mount(compA)
+    expect(() => wrapper.getComponent({ name: 'CompB' })).toThrowError(
+      'Unable to get component with name CompB within: <div class="A"></div>'
+    )
+  })
+
+  it('should throw if not found with a component selector that has a name', () => {
+    const wrapper = mount(compA)
+    expect(() => wrapper.getComponent(compB)).toThrowError(
+      'Unable to get component with name CompB within: <div class="A"></div>'
+    )
+  })
+
+  it('should throw if not found with a ref selector', () => {
+    const wrapper = mount(compA)
+    expect(() => wrapper.getComponent({ ref: 'CompB' })).toThrowError(
+      'Unable to get component with ref CompB within: <div class="A"></div>'
+    )
+  })
+
+  it('should throw if not found with a component selector that has no name', () => {
+    const wrapper = mount(compA)
+    expect(() => wrapper.getComponent(compA)).toThrowError(
+      'Unable to get specified component within: <div class="A"></div>'
     )
   })
 })


### PR DESCRIPTION
As the selector can have different shapes, this improve the error message to be more friendly.