### PR TITLE
feat: split attrs and props mounting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ component | ✅ | (new!) nested in [`global`](https://vuejs.github.io/vue-test-u
 directives | ✅ | (new!) nested in [`global`](https://vuejs.github.io/vue-test-utils-next-docs/api/#global)
 stubs | ✅ 
 attachToDocument |✅| renamed `attachTo`. See [here](https://github.com/vuejs/vue-test-utils/pull/1492)
-attrs | ⚰️ | use `props` instead, it assigns both attributes and props. 
+attrs | ✅ 
 scopedSlots | ⚰️ | scopedSlots are merged with slots in Vue 3
 context | ⚰️ | different from Vue 2, does not make sense anymore.
 localVue | ⚰️ | may not make sense anymore since we do not mutate the global Vue instance in Vue 3.

--- a/src/vue-shims.d.ts
+++ b/src/vue-shims.d.ts
@@ -3,8 +3,3 @@ declare module '*.vue' {
   import Vue from 'vue'
   export default any
 }
-
-declare module 'vue' {
-  import Vue from 'vue/dist/vue'
-  export = Vue
-}

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -94,3 +94,8 @@ expectError(
     props: { b: 'Hello' }
   }))
 )
+
+// except if explicitly cast
+mount(AppWithoutProps, {
+  props: { b: 'Hello' } as never
+})

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -7,21 +7,25 @@ const AppWithDefine = defineComponent({
     a: {
       type: String,
       required: true
-    }
+    },
+    b: Number
   },
   template: ''
 })
 
 // accept props
 let wrapper = mount(AppWithDefine, {
-  props: { a: 'Hello' }
+  props: { a: 'Hello', b: 2 }
 })
 // vm is properly typed
 expectType<string>(wrapper.vm.a)
 
 // can receive extra props
+// ideally, it should not
+// but the props have type { a: string } & VNodeProps
+// which allows any property
 mount(AppWithDefine, {
-  props: { a: 'Hello', b: 2 }
+  props: { a: 'Hello', c: 2 }
 })
 
 // wrong prop type should not compile
@@ -48,10 +52,12 @@ wrapper = mount(AppWithProps, {
 // vm is properly typed
 expectType<string>(wrapper.vm.a)
 
-// can receive extra props
-mount(AppWithProps, {
-  props: { a: 'Hello', b: 2 }
-})
+// can't receive extra props
+expectError(
+  mount(AppWithProps, {
+    props: { a: 'Hello', b: 2 }
+  })
+)
 
 // wrong prop type should not compile
 expectError(
@@ -73,6 +79,7 @@ wrapper = mount(AppWithArrayProps, {
 expectType<string>(wrapper.vm.a)
 
 // can receive extra props
+// as they are declared as `string[]`
 mount(AppWithArrayProps, {
   props: { a: 'Hello', b: 2 }
 })
@@ -81,7 +88,9 @@ const AppWithoutProps = {
   template: ''
 }
 
-// can receive extra props
-wrapper = mount(AppWithoutProps, {
-  props: { b: 'Hello' }
-})
+// can't receive extra props
+expectError(
+  (wrapper = mount(AppWithoutProps, {
+    props: { b: 'Hello' }
+  }))
+)

--- a/tests/mountingOptions/attrs.spec.ts
+++ b/tests/mountingOptions/attrs.spec.ts
@@ -1,0 +1,57 @@
+import { defineComponent, h } from 'vue'
+import { mount } from '../../src'
+
+describe('mountingOptions.attrs', () => {
+  const Component = defineComponent({
+    props: {
+      message: {
+        type: String,
+        required: true
+      },
+      otherMessage: {
+        type: String
+      }
+    },
+
+    render() {
+      return h('div', {}, `Message is ${this.message}`)
+    }
+  })
+
+  test('assigns extra attributes on components', () => {
+    const wrapper = mount(Component, {
+      props: {
+        message: 'Hello World'
+      },
+      attrs: {
+        class: 'HelloFromTheOtherSide',
+        id: 'hello',
+        disabled: true
+      }
+    })
+
+    expect(wrapper.attributes()).toEqual({
+      class: 'HelloFromTheOtherSide',
+      disabled: 'true',
+      id: 'hello'
+    })
+
+    expect(wrapper.props()).toEqual({
+      message: 'Hello World'
+    })
+  })
+
+  test('assigns event listeners', async () => {
+    const Component = {
+      template: '<button @click="$emit(\'customEvent\', true)">Click</button>'
+    }
+    const onCustomEvent = jest.fn()
+    const wrapper = mount(Component, { attrs: { onCustomEvent } })
+    const button = wrapper.find('button')
+    await button.trigger('click')
+    await button.trigger('click')
+    await button.trigger('click')
+
+    expect(onCustomEvent).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/mountingOptions/attrs.spec.ts
+++ b/tests/mountingOptions/attrs.spec.ts
@@ -41,17 +41,20 @@ describe('mountingOptions.attrs', () => {
     })
   })
 
-  test('assigns event listeners', async () => {
-    const Component = {
-      template: '<button @click="$emit(\'customEvent\', true)">Click</button>'
-    }
-    const onCustomEvent = jest.fn()
-    const wrapper = mount(Component, { attrs: { onCustomEvent } })
-    const button = wrapper.find('button')
-    await button.trigger('click')
-    await button.trigger('click')
-    await button.trigger('click')
+  test('is overridden by a prop with the same name', () => {
+    const wrapper = mount(Component, {
+      props: {
+        message: 'Hello World'
+      },
+      attrs: {
+        message: 'HelloFromTheOtherSide'
+      }
+    })
 
-    expect(onCustomEvent).toHaveBeenCalledTimes(3)
+    expect(wrapper.props()).toEqual({
+      message: 'Hello World'
+    })
+
+    expect(wrapper.attributes()).toEqual({})
   })
 })

--- a/tests/mountingOptions/props.spec.ts
+++ b/tests/mountingOptions/props.spec.ts
@@ -26,16 +26,21 @@ describe('mountingOptions.props', () => {
     expect(wrapper.text()).toBe('Message is Hello')
   })
 
-  test('assigns extra attributes on components', () => {
+  test('assigns extra properties as attributes on components', () => {
+    // the recommended way is to use `attrs` though
+    // and ideally it should not even compile, but props is too loosely typed
+    // for components defined with `defineComponent`
     const wrapper = mount(Component, {
       props: {
-        message: 'Hello World'
-      },
-      attrs: {
+        message: 'Hello World',
         class: 'HelloFromTheOtherSide',
         id: 'hello',
         disabled: true
       }
+    })
+
+    expect(wrapper.props()).toEqual({
+      message: 'Hello World'
     })
 
     expect(wrapper.attributes()).toEqual({
@@ -43,23 +48,5 @@ describe('mountingOptions.props', () => {
       disabled: 'true',
       id: 'hello'
     })
-
-    expect(wrapper.props()).toEqual({
-      message: 'Hello World'
-    })
-  })
-
-  test('assigns event listeners', async () => {
-    const Component = {
-      template: '<button @click="$emit(\'customEvent\', true)">Click</button>'
-    }
-    const onCustomEvent = jest.fn()
-    const wrapper = mount(Component, { props: { onCustomEvent } })
-    const button = wrapper.find('button')
-    await button.trigger('click')
-    await button.trigger('click')
-    await button.trigger('click')
-
-    expect(onCustomEvent).toHaveBeenCalledTimes(3)
   })
 })

--- a/tests/mountingOptions/props.spec.ts
+++ b/tests/mountingOptions/props.spec.ts
@@ -49,4 +49,19 @@ describe('mountingOptions.props', () => {
       id: 'hello'
     })
   })
+
+  test('assigns event listeners', async () => {
+    const Component = {
+      template: '<button @click="$emit(\'customEvent\', true)">Click</button>'
+    }
+    const onCustomEvent = jest.fn()
+    // Note that, as the component does not have any props declared, we need to cast the mounting props
+    const wrapper = mount(Component, { props: { onCustomEvent } as never })
+    const button = wrapper.find('button')
+    await button.trigger('click')
+    await button.trigger('click')
+    await button.trigger('click')
+
+    expect(onCustomEvent).toHaveBeenCalledTimes(3)
+  })
 })

--- a/tests/mountingOptions/props.spec.ts
+++ b/tests/mountingOptions/props.spec.ts
@@ -1,22 +1,23 @@
 import { defineComponent, h } from 'vue'
-import WithProps from '../components/WithProps.vue'
 import { mount } from '../../src'
 
 describe('mountingOptions.props', () => {
-  test('passes props', () => {
-    const Component = defineComponent({
-      props: {
-        message: {
-          type: String,
-          required: true
-        }
+  const Component = defineComponent({
+    props: {
+      message: {
+        type: String,
+        required: true
       },
-
-      render() {
-        return h('div', {}, `Message is ${this.message}`)
+      otherMessage: {
+        type: String
       }
-    })
+    },
 
+    render() {
+      return h('div', {}, `Message is ${this.message}`)
+    }
+  })
+  test('passes props', () => {
     const wrapper = mount(Component, {
       props: {
         message: 'Hello'
@@ -26,12 +27,14 @@ describe('mountingOptions.props', () => {
   })
 
   test('assigns extra attributes on components', () => {
-    const wrapper = mount(WithProps, {
+    const wrapper = mount(Component, {
       props: {
+        message: 'Hello World'
+      },
+      attrs: {
         class: 'HelloFromTheOtherSide',
         id: 'hello',
-        disabled: true,
-        msg: 'Hello World'
+        disabled: true
       }
     })
 
@@ -42,7 +45,7 @@ describe('mountingOptions.props', () => {
     })
 
     expect(wrapper.props()).toEqual({
-      msg: 'Hello World'
+      message: 'Hello World'
     })
   })
 


### PR DESCRIPTION
This allows a slightly better type checking, even if `defineComponent({ props: { a: String }})` sadly has `$props` typed as `{ a: string } & VNodeProps` and `VNodeProps` allows anything. I'm not sure we can do much on VTU side for now.

See https://github.com/vuejs/vue-test-utils-next/pull/90 for context