### PR TITLE
refactor: eliminate need for error wrapper class

### DIFF
--- a/src/dom-wrapper.ts
+++ b/src/dom-wrapper.ts
@@ -54,7 +54,7 @@ export class DOMWrapper<ElementType extends Element> {
       return new DOMWrapper(result)
     }
 
-    return createWrapperError({ selector })
+    return createWrapperError('DOMWrapper')
   }
 
   get<K extends keyof HTMLElementTagNameMap>(

--- a/src/dom-wrapper.ts
+++ b/src/dom-wrapper.ts
@@ -54,8 +54,7 @@ export class DOMWrapper<ElementType extends Element> {
       return new DOMWrapper(result)
     }
 
-    createWrapperError({ selector })
-    // return new ErrorWrapper({ selector })
+    return createWrapperError({ selector })
   }
 
   get<K extends keyof HTMLElementTagNameMap>(
@@ -67,11 +66,11 @@ export class DOMWrapper<ElementType extends Element> {
   get<T extends Element>(selector: string): DOMWrapper<T>
   get(selector: string): DOMWrapper<Element> {
     const result = this.find(selector)
-    // if (result instanceof ErrorWrapper) {
-    //   throw new Error(`Unable to find ${selector} within: ${this.html()}`)
-    // }
+    if (result instanceof DOMWrapper) {
+      return result
+    }
 
-    return result
+    throw new Error(`Unable to get ${selector} within: ${this.html()}`)
   }
 
   findAll<K extends keyof HTMLElementTagNameMap>(

--- a/src/dom-wrapper.ts
+++ b/src/dom-wrapper.ts
@@ -1,18 +1,16 @@
 import { nextTick } from 'vue'
 
-import { WrapperAPI } from './types'
-import { ErrorWrapper } from './error-wrapper'
-
+import { createWrapperError } from './error-wrapper'
 import { TriggerOptions, createDOMEvent } from './create-dom-event'
 
-export class DOMWrapper<ElementType extends Element> implements WrapperAPI {
+export class DOMWrapper<ElementType extends Element> {
   element: ElementType
 
   constructor(element: ElementType) {
     this.element = element
   }
 
-  classes(className?) {
+  classes(className?: string) {
     const classes = this.element.classList
 
     if (className) return classes.contains(className)
@@ -45,18 +43,19 @@ export class DOMWrapper<ElementType extends Element> implements WrapperAPI {
 
   find<K extends keyof HTMLElementTagNameMap>(
     selector: K
-  ): DOMWrapper<HTMLElementTagNameMap[K]> | ErrorWrapper
+  ): DOMWrapper<HTMLElementTagNameMap[K]>
   find<K extends keyof SVGElementTagNameMap>(
     selector: K
-  ): DOMWrapper<SVGElementTagNameMap[K]> | ErrorWrapper
-  find<T extends Element>(selector: string): DOMWrapper<T> | ErrorWrapper
-  find(selector: string): DOMWrapper<Element> | ErrorWrapper {
+  ): DOMWrapper<SVGElementTagNameMap[K]>
+  find<T extends Element>(selector: string): DOMWrapper<T>
+  find(selector: string): DOMWrapper<Element> {
     const result = this.element.querySelector(selector)
     if (result) {
       return new DOMWrapper(result)
     }
 
-    return new ErrorWrapper({ selector })
+    createWrapperError({ selector })
+    // return new ErrorWrapper({ selector })
   }
 
   get<K extends keyof HTMLElementTagNameMap>(
@@ -68,9 +67,9 @@ export class DOMWrapper<ElementType extends Element> implements WrapperAPI {
   get<T extends Element>(selector: string): DOMWrapper<T>
   get(selector: string): DOMWrapper<Element> {
     const result = this.find(selector)
-    if (result instanceof ErrorWrapper) {
-      throw new Error(`Unable to find ${selector} within: ${this.html()}`)
-    }
+    // if (result instanceof ErrorWrapper) {
+    //   throw new Error(`Unable to find ${selector} within: ${this.html()}`)
+    // }
 
     return result
   }

--- a/src/error-wrapper.ts
+++ b/src/error-wrapper.ts
@@ -1,70 +1,36 @@
-import { FindComponentSelector } from './types'
+import { ComponentPublicInstance } from 'vue'
 
-interface Options {
-  selector: FindComponentSelector
+import { DOMWrapper } from './dom-wrapper'
+import { VueWrapper } from './vue-wrapper'
+
+interface ErrorWrapperOptions {
+  selector?: string
 }
 
-export class ErrorWrapper {
-  selector: FindComponentSelector
-  element: null
+export function createWrapperError(options?: ErrorWrapperOptions) {
+  return new Proxy<DOMWrapper<Element>>(Object.create(null), {
+    get(obj, prop) {
+      switch (prop) {
+        case 'exists':
+          return () => false
+        default:
+          throw new Error(`Cannot call ${String(prop)} on an empty DOMWrapper.`)
+      }
+    }
+  })
+}
 
-  constructor({ selector }: Options) {
-    this.selector = selector
-  }
-
-  wrapperError(method: string): Error {
-    return Error(`Cannot call ${method} on an empty wrapper.`)
-  }
-
-  vm(): Error {
-    throw this.wrapperError('vm')
-  }
-
-  attributes() {
-    throw this.wrapperError('attributes')
-  }
-
-  classes() {
-    throw this.wrapperError('classes')
-  }
-
-  exists() {
-    return false
-  }
-
-  find(): never {
-    throw this.wrapperError('find')
-  }
-
-  get(): never {
-    throw this.wrapperError('get')
-  }
-
-  findAll(): never {
-    throw this.wrapperError('findAll')
-  }
-
-  setProps() {
-    throw this.wrapperError('setProps')
-  }
-
-  setValue() {
-    throw this.wrapperError('setValue')
-  }
-
-  props() {
-    throw this.wrapperError('props')
-  }
-
-  text() {
-    throw this.wrapperError('text')
-  }
-
-  trigger() {
-    throw this.wrapperError('trigger')
-  }
-
-  unmount() {
-    throw this.wrapperError('unmount')
-  }
+export function createVueWrapperError<T extends ComponentPublicInstance>(
+  options?: ErrorWrapperOptions
+) {
+  return new Proxy<VueWrapper<T>>(Object.create(null), {
+    get(obj, prop) {
+      switch (prop) {
+        case 'exists':
+          return () => false
+        default:
+          throw new Error(`Cannot call ${String(prop)} on an empty VueWrapper.`)
+      }
+    }
+  })
 }

--- a/src/error-wrapper.ts
+++ b/src/error-wrapper.ts
@@ -1,35 +1,15 @@
-import { ComponentPublicInstance } from 'vue'
-
-import { DOMWrapper } from './dom-wrapper'
-import { VueWrapper } from './vue-wrapper'
-
-interface ErrorWrapperOptions {
-  selector?: string
-}
-
-export function createWrapperError(options?: ErrorWrapperOptions) {
-  return new Proxy<DOMWrapper<Element>>(Object.create(null), {
-    get(obj, prop) {
-      switch (prop) {
-        case 'exists':
-          return () => false
-        default:
-          throw new Error(`Cannot call ${String(prop)} on an empty DOMWrapper.`)
-      }
-    }
-  })
-}
-
-export function createVueWrapperError<T extends ComponentPublicInstance>(
-  options?: ErrorWrapperOptions
+export function createWrapperError<T extends object>(
+  wrapperType: 'DOMWrapper' | 'VueWrapper'
 ) {
-  return new Proxy<VueWrapper<T>>(Object.create(null), {
+  return new Proxy<T>(Object.create(null), {
     get(obj, prop) {
       switch (prop) {
         case 'exists':
           return () => false
         default:
-          throw new Error(`Cannot call ${String(prop)} on an empty VueWrapper.`)
+          throw new Error(
+            `Cannot call ${String(prop)} on an empty ${wrapperType}.`
+          )
       }
     }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { mount } from './mount'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { VueWrapper } from './vue-wrapper'
+import { DOMWrapper } from './dom-wrapper'
 import { config } from './config'
 
-export { mount, RouterLinkStub, VueWrapper, config }
+export { mount, RouterLinkStub, VueWrapper, DOMWrapper, config }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -10,7 +10,7 @@ interface IStubOptions {
 // TODO: figure out how to type this
 type VNodeArgs = any[]
 
-export const createStub = ({ name, props }: IStubOptions) => {
+const createStub = ({ name, props }: IStubOptions) => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
   const render = () => h(tag)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,24 +1,5 @@
 import { Component, ComponentOptions, Directive, Plugin } from 'vue'
 
-import { DOMWrapper } from './dom-wrapper'
-import { ErrorWrapper } from './error-wrapper'
-
-export interface WrapperAPI {
-  attributes: (key?: string) => string | Record<string, string>
-  classes: (className?: string) => string[] | boolean | ErrorWrapper
-  readonly element: Element
-  exists: () => boolean
-  get<T extends Element>(selector: string): DOMWrapper<T>
-  find<T extends Element>(selector: string): DOMWrapper<T> | ErrorWrapper
-  findAll<T extends Element>(selector: string): DOMWrapper<T>[]
-  html: () => string
-  text: () => string
-  trigger: (
-    eventString: string,
-    options?: Object
-  ) => Promise<(fn?: () => void) => Promise<void>>
-}
-
 interface RefSelector {
   ref: string
 }

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -4,7 +4,7 @@ import { config } from './config'
 
 import { DOMWrapper } from './dom-wrapper'
 import { FindAllComponentsSelector, FindComponentSelector } from './types'
-import { createWrapperError, createVueWrapperError } from './error-wrapper'
+import { createWrapperError } from './error-wrapper'
 import { TriggerOptions } from './create-dom-event'
 import { find } from './utils/find'
 
@@ -92,7 +92,7 @@ export class VueWrapper<T extends ComponentPublicInstance> {
       return new DOMWrapper(result)
     }
 
-    return createWrapperError({ selector })
+    return createWrapperError('DOMWrapper')
   }
 
   get<K extends keyof HTMLElementTagNameMap>(
@@ -132,7 +132,7 @@ export class VueWrapper<T extends ComponentPublicInstance> {
       return createWrapper(null, result[0])
     }
 
-    return createVueWrapperError<T>({ selector })
+    return createWrapperError('VueWrapper')
   }
 
   getComponent<T extends ComponentPublicInstance>(

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -8,7 +8,6 @@ import { createWrapperError } from './error-wrapper'
 import { TriggerOptions } from './create-dom-event'
 import { find } from './utils/find'
 
-// @ts-ignore
 export class VueWrapper<T extends ComponentPublicInstance> {
   private componentVM: T
   private rootVM: ComponentPublicInstance

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -103,12 +103,12 @@ export class VueWrapper<T extends ComponentPublicInstance> {
   ): DOMWrapper<SVGElementTagNameMap[K]>
   get<T extends Element>(selector: string): DOMWrapper<T>
   get(selector: string): DOMWrapper<Element> {
-    const result = this.parentElement.querySelector(selector)
-    if (!result) {
-      throw new Error(`Unable to get ${selector} within: ${this.html()}`)
+    const result = this.find(selector)
+    if (result instanceof DOMWrapper) {
+      return result
     }
 
-    return new DOMWrapper(result)
+    throw new Error(`Unable to get ${selector} within: ${this.html()}`)
   }
 
   findComponent<T extends ComponentPublicInstance>(

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentPublicInstance } from 'vue'
 
-import { mount, config } from '../../src'
-import { WrapperAPI } from '../../src/types'
+import { mount, config, VueWrapper } from '../../src'
 
 declare module '../../src/vue-wrapper' {
   interface VueWrapper<T extends ComponentPublicInstance> {
@@ -29,7 +28,7 @@ describe('Plugin', () => {
     })
 
     it('receives the wrapper inside the plugin setup', () => {
-      const plugin = (wrapper: WrapperAPI) => {
+      const plugin = (wrapper: VueWrapper<ComponentPublicInstance>) => {
         return {
           $el: wrapper.element // simple aliases
         }

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -38,6 +38,17 @@ describe('find', () => {
     expect(wrapper.find('.foo').exists()).toBe(true)
   })
 
+  it('can be chained', () => {
+    const Component = defineComponent({
+      render() {
+        return h('div', { class: 'foo' }, [h('div', { class: 'bar' })])
+      }
+    })
+
+    const wrapper = mount(Component)
+    expect(wrapper.find('.foo').find('.bar').exists()).toBe(true)
+  })
+
   test('works with suspense', async () => {
     const wrapper = mount(SuspenseComponent)
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,0 @@
-/**
- * simulate a delay (eg, API call).
- */
-export const simulateDelay = ({ delayInMs }: { delayInMs: number }) => {
-  return new Promise((res) => setTimeout(res, delayInMs))
-}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * simulate a delay (eg, API call).
+ */
+export const simulateDelay = ({ delayInMs }: { delayInMs: number }) => {
+  return new Promise((res) => setTimeout(res, delayInMs))
+}


### PR DESCRIPTION
Greatly simplify the concept of `ErrorWrapper` and eliminate the need for the `WrapperAPI` interfaces (since they are not implemented by more than one class).

It's everyone favorite kind of PR - one that has more deletions than insertions!

#91  and #92