### PR TITLE
types: Assign the correct typing for vnodes

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,4 +1,4 @@
-import { transformVNodeArgs, h } from 'vue'
+import { transformVNodeArgs, h, createVNode } from 'vue'
 import { hyphenate } from '@vue/shared'
 import { matchName } from './utils/matchName'
 
@@ -7,8 +7,7 @@ interface IStubOptions {
   props: any
 }
 
-// TODO: figure out how to type this
-type VNodeArgs = any[]
+type VNodeArgs = Parameters<typeof createVNode>
 
 export const createStub = ({ name, props }: IStubOptions) => {
   const anonName = 'anonymous-stub'


### PR DESCRIPTION
A more correct type would be:
```ts
type VNodeArgs = Parameters<Parameters<typeof transformVNodeArgs>[0]>[0]
```
But it's a bit harder to read