### PR TITLE
POC - Render all stub slots via config 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 import { GlobalMountOptions } from './types'
 
-export const config: { global: GlobalMountOptions } = {
-  global: {}
+type Config = { global: GlobalMountOptions; renderAllStubSlots: boolean }
+
+export const config: Config = {
+  global: {},
+  renderAllStubSlots: false
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
 import { GlobalMountOptions } from './types'
 
-type Config = { global: GlobalMountOptions; renderAllStubSlots: boolean }
+type Config = { global: GlobalMountOptions; renderStubDefaultSlot: boolean }
 
 export const config: Config = {
   global: {},
-  renderAllStubSlots: false
+  renderStubDefaultSlot: false
 }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -12,12 +12,7 @@ interface IStubOptions {
 type VNodeArgs = any[]
 
 function getSlots(ctx) {
-  return config.renderAllStubSlots
-    ? Object.entries(ctx.$slots)
-        .filter(([name]) => name !== '_')
-        // @ts-ignore
-        .map(([name, slot]) => slot.call(ctx, {}))
-    : ctx.$slots
+  return !config.renderStubDefaultSlot ? undefined : ctx.$slots
 }
 
 export const createStub = ({ name, props }: IStubOptions) => {
@@ -25,8 +20,7 @@ export const createStub = ({ name, props }: IStubOptions) => {
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 
   const render = (ctx) => {
-    const slots = getSlots(ctx)
-    return h(tag, {}, slots)
+    return h(tag, {}, getSlots(ctx))
   }
 
   return { name: name || anonName, render, props }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -13,7 +13,7 @@ type VNodeArgs = any[]
 export const createStub = ({ name, props }: IStubOptions) => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
-  const render = () => h(tag)
+  const render = (ctx) => h(tag, {}, ctx.$slots)
 
   return { name: name || anonName, render, props }
 }
@@ -77,7 +77,7 @@ export function stubComponents(stubs: Record<any, any>) {
         return [
           createStub({ name, props: propsDeclaration }),
           props,
-          {},
+          children,
           patchFlag,
           dynamicProps
         ]

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,5 +1,6 @@
 import { transformVNodeArgs, h } from 'vue'
 import { hyphenate } from '@vue/shared'
+import { config } from './index'
 import { matchName } from './utils/matchName'
 
 interface IStubOptions {
@@ -10,10 +11,23 @@ interface IStubOptions {
 // TODO: figure out how to type this
 type VNodeArgs = any[]
 
+function getSlots(ctx) {
+  return config.renderAllStubSlots
+    ? Object.entries(ctx.$slots)
+        .filter(([name]) => name !== '_')
+        // @ts-ignore
+        .map(([name, slot]) => slot.call(ctx, {}))
+    : ctx.$slots
+}
+
 export const createStub = ({ name, props }: IStubOptions) => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
-  const render = (ctx) => h(tag, {}, ctx.$slots)
+
+  const render = (ctx) => {
+    const slots = getSlots(ctx)
+    return h(tag, {}, slots)
+  }
 
   return { name: name || anonName, render, props }
 }

--- a/tests/components/ComponentWithSlots.vue
+++ b/tests/components/ComponentWithSlots.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="ComponentWithSlots">
+    <slot />
+    <slot name="named" />
+    <slot name="withDefault">With Default Content</slot>
+    <slot name="scoped" v-bind="{ boolean, string, object }" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ComponentWithSlots',
+  data () {
+    return {
+      boolean: true,
+      string: 'string',
+      object: { foo: 'foo' }
+    }
+  }
+}
+</script>

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -1,6 +1,6 @@
 import { h, ComponentOptions } from 'vue'
 
-import { mount } from '../../src'
+import { config, mount } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
@@ -302,23 +302,46 @@ describe('mounting options: stubs', () => {
     expect(wrapper.html()).toBe('<foo-bar-stub></foo-bar-stub>')
   })
 
-  it('renders stub slots by default', () => {
+  describe('stub slots', () => {
     const Component = {
       name: 'Parent',
-      template: `<div><component-with-slots>
-        <template #default>Default</template>
-        <template #named>A named</template>
-        <template #noop>A not existing one</template>
-      </component-with-slots></div>`,
+      template: `
+        <div>
+          <component-with-slots>
+            <template #default>Default</template>
+            <template #named>A named</template>
+            <template #noop>A not existing one</template>
+            <template #scoped="{ boolean, string }">{{ boolean }} {{ string }}</template>
+          </component-with-slots>
+        </div>`,
       components: { ComponentWithSlots }
     }
-    const wrapper = mount(Component, {
-      global: {
-        stubs: ['ComponentWithSlots']
-      }
+
+    afterEach(() => {
+      config.renderAllStubSlots = false
     })
-    expect(wrapper.html()).toBe(
-      '<div><component-with-slots-stub>Default A named With Default Content</component-with-slots-stub></div>'
-    )
+
+    it('renders only the default stub slot by default', () => {
+      const wrapper = mount(Component, {
+        global: {
+          stubs: ['ComponentWithSlots']
+        }
+      })
+      expect(wrapper.html()).toBe(
+        `<div><component-with-slots-stub>Default</component-with-slots-stub></div>`
+      )
+    })
+
+    it('renders all provided stub slots', () => {
+      config.renderAllStubSlots = true
+      const wrapper = mount(Component, {
+        global: {
+          stubs: ['ComponentWithSlots']
+        }
+      })
+      expect(wrapper.html()).toBe(
+        '<div><component-with-slots-stub>DefaultA namedA not existing one </component-with-slots-stub></div>'
+      )
+    })
   })
 })

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -3,6 +3,7 @@ import { h, ComponentOptions } from 'vue'
 import { mount } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'
+import ComponentWithSlots from '../components/ComponentWithSlots.vue'
 
 describe('mounting options: stubs', () => {
   it('handles Array syntax', () => {
@@ -299,5 +300,25 @@ describe('mounting options: stubs', () => {
     })
 
     expect(wrapper.html()).toBe('<foo-bar-stub></foo-bar-stub>')
+  })
+
+  it('renders stub slots by default', () => {
+    const Component = {
+      name: 'Parent',
+      template: `<div><component-with-slots>
+        <template #default>Default</template>
+        <template #named>A named</template>
+        <template #noop>A not existing one</template>
+      </component-with-slots></div>`,
+      components: { ComponentWithSlots }
+    }
+    const wrapper = mount(Component, {
+      global: {
+        stubs: ['ComponentWithSlots']
+      }
+    })
+    expect(wrapper.html()).toBe(
+      '<div><component-with-slots-stub>Default A named With Default Content</component-with-slots-stub></div>'
+    )
   })
 })

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -343,5 +343,40 @@ describe('mounting options: stubs', () => {
         '<div><component-with-slots-stub>DefaultA namedA not existing one </component-with-slots-stub></div>'
       )
     })
+
+    it('renders the default slot of deeply nested stubs by default', () => {
+      const SimpleSlot = {
+        name: 'SimpleSlot',
+        template: '<div class="simpleSlot"><slot/></div>'
+      }
+      const WrappingComponent = {
+        template: `
+          <component-with-slots>
+            <component-with-slots>
+              <simple-slot>
+                <template #default>nested content</template>
+                <template #not-existing>not rendered</template>
+              </simple-slot>
+            </component-with-slots>
+          </component-with-slots>`,
+        components: {
+          ComponentWithSlots,
+          SimpleSlot
+        }
+      }
+      const wrapper = mount(WrappingComponent, {
+        global: {
+          stubs: ['component-with-slots', 'simple-slot']
+        }
+      })
+
+      expect(wrapper.html()).toEqual(
+        '<component-with-slots-stub>' +
+          '<component-with-slots-stub>' +
+          '<simple-slot-stub>nested content</simple-slot-stub>' +
+          '</component-with-slots-stub>' +
+          '</component-with-slots-stub>'
+      )
+    })
   })
 })

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -318,10 +318,12 @@ describe('mounting options: stubs', () => {
     }
 
     afterEach(() => {
-      config.renderAllStubSlots = false
+      config.renderStubDefaultSlot = false
     })
 
-    it('renders only the default stub slot by default', () => {
+    it('renders only the default stub slot only behind flag', () => {
+      config.renderStubDefaultSlot = true
+
       const wrapper = mount(Component, {
         global: {
           stubs: ['ComponentWithSlots']
@@ -332,19 +334,21 @@ describe('mounting options: stubs', () => {
       )
     })
 
-    it('renders all provided stub slots', () => {
-      config.renderAllStubSlots = true
+    it('renders none of the slots on a stub', () => {
+      config.renderStubDefaultSlot = false
       const wrapper = mount(Component, {
         global: {
           stubs: ['ComponentWithSlots']
         }
       })
       expect(wrapper.html()).toBe(
-        '<div><component-with-slots-stub>DefaultA namedA not existing one </component-with-slots-stub></div>'
+        '<div><component-with-slots-stub></component-with-slots-stub></div>'
       )
     })
 
-    it('renders the default slot of deeply nested stubs by default', () => {
+    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', () => {
+      config.renderStubDefaultSlot = true
+
       const SimpleSlot = {
         name: 'SimpleSlot',
         template: '<div class="simpleSlot"><slot/></div>'


### PR DESCRIPTION
This is what I got... and I am not sure I like it...

1. Scoped slots just cannot work with auto stubs and `shallowMount`.
1. We cannot know what slots a component has defined, we can just render everything.

Check it out, play with it if you want. I wanted Evan to give me an advice on this, but yeah...

Related to #69 