### PR TITLE
fix(mount): throws if unknown attachTo

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -84,6 +84,11 @@ export function mount(
       ? document.querySelector(options.attachTo)
       : options.attachTo
 
+    if (!to) {
+      throw new Error(
+        `Unable to find the element matching the selector ${options.attachTo} given as the \`attachTo\` option`
+      )
+    }
     to.appendChild(el)
   }
 

--- a/tests/mountingOptions/attachTo.spec.ts
+++ b/tests/mountingOptions/attachTo.spec.ts
@@ -45,5 +45,15 @@ describe('options.attachTo', () => {
     expect(document.getElementById('attach-to')).toBeNull()
   })
 
+  it('throws if the provided CSS selector string can not be find', () => {
+    expect(() =>
+      mount(TestComponent, {
+        attachTo: '#unknown' // attach to an unknown selector
+      })
+    ).toThrowError(
+      'Unable to find the element matching the selector #unknown given as the `attachTo` option'
+    )
+  })
+
   it.todo('correctly hydrates markup')
 })


### PR DESCRIPTION
As `attachTo` can be a CSS selector, if the provided selector can not be found by `document.querySelector` than an obscure error is thrown `Cannot read property 'appendChild' of null`. This handles such a case to throw a more intuitive error.

    Unable to find the element matching the selector #unknown given as the `attachTo` option