### PR TITLE
feat: improve mount typings when using object syntax and infer Data type

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -34,8 +34,8 @@ import { stubComponents } from './stubs'
 
 type Slot = VNode | string | { render: Function }
 
-interface MountingOptions<Props, Data = {}> {
-  data?: () => Data
+interface MountingOptions<Props, Data extends object = {}> {
+  data?: () => Data extends unknown ? never : Data
   props?: Props
   attrs?: Record<string, unknown>
   slots?: {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -35,7 +35,7 @@ import { stubComponents } from './stubs'
 type Slot = VNode | string | { render: Function }
 
 interface MountingOptions<Props, Data = {}> {
-  data?: () => unknown extends Data ? never : Partial<Data>
+  data?: () => Data extends object ? Partial<Data> : never
   props?: Props
   attrs?: Record<string, unknown>
   slots?: {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -35,7 +35,7 @@ import { stubComponents } from './stubs'
 type Slot = VNode | string | { render: Function }
 
 interface MountingOptions<Props, Data = {}> {
-  data?: () => Data extends unknown ? never : Data
+  data?: () => unknown extends Data ? never : Partial<Data>
   props?: Props
   attrs?: Record<string, unknown>
   slots?: {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -34,7 +34,7 @@ import { stubComponents } from './stubs'
 
 type Slot = VNode | string | { render: Function }
 
-interface MountingOptions<Props, Data extends object = {}> {
+interface MountingOptions<Props, Data = {}> {
   data?: () => Data extends unknown ? never : Data
   props?: Props
   attrs?: Record<string, unknown>
@@ -102,7 +102,7 @@ export function mount<
     E,
     EE
   >,
-  options?: MountingOptions<Props, D>
+  options?: MountingOptions<never, D>
 ): VueWrapper<
   ComponentPublicInstance<Props, RawBindings, D, C, M, E, VNodeProps & Props>
 >

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -64,35 +64,19 @@ export type ObjectEmitsOptions = Record<
 export type EmitsOptions = ObjectEmitsOptions | string[]
 
 // Functional component
-export function mount<TestedComponent extends FunctionalComponent>(
+export function mount<
+  TestedComponent extends FunctionalComponent<Props>,
+  Props
+>(
   originalComponent: TestedComponent,
-  options?: MountingOptions<any>
-): VueWrapper<ComponentPublicInstance>
+  options?: MountingOptions<Props>
+): VueWrapper<ComponentPublicInstance<Props>>
+
 // Component declared with defineComponent
 export function mount<TestedComponent extends ComponentPublicInstance>(
   originalComponent: { new (): TestedComponent } & Component,
   options?: MountingOptions<TestedComponent['$props'], TestedComponent['$data']>
 ): VueWrapper<TestedComponent>
-
-// Functional Component declared with (props, ctx)=> render
-export function mount<Props, RawBindings = object>(
-  setup: (
-    props: Readonly<Props>,
-    ctx: SetupContext
-  ) => RawBindings | RenderFunction,
-
-  options: MountingOptions<Props, {}>
-): VueWrapper<
-  ComponentPublicInstance<
-    Props,
-    RawBindings,
-    {},
-    {},
-    {},
-    // public props
-    VNodeProps & Props
-  >
->
 
 // Component declared with no props
 export function mount<

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -91,9 +91,11 @@ expectType<string>(
 
 // can receive extra props
 // as they are declared as `string[]`
-mount(AppWithArrayProps, {
-  props: { a: 'Hello', b: 2 }
-})
+expectType<number>(
+  mount(AppWithArrayProps, {
+    props: { a: 'Hello', b: 2 }
+  }).vm.b
+)
 
 // cannot receive extra props
 // if they pass use object inside
@@ -125,3 +127,20 @@ expectError(
 mount(AppWithoutProps, {
   props: { b: 'Hello' } as never
 })
+
+// Functional tests
+
+// wrong props
+expectError((props: { a: 1 }) => {}, {
+  props: {
+    a: '222'
+  }
+})
+
+expectType<number>(
+  mount((props: { a: 1 }, ctx) => {}, {
+    props: {
+      a: 22
+    }
+  }).vm.a
+)

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -13,12 +13,12 @@ const AppWithDefine = defineComponent({
   template: ''
 })
 
-// accept props
-let wrapper = mount(AppWithDefine, {
-  props: { a: 'Hello', b: 2 }
-})
-// vm is properly typed
-expectType<string>(wrapper.vm.a)
+// accept props- vm is properly typed
+expectType<string>(
+  mount(AppWithDefine, {
+    props: { a: 'Hello', b: 2 }
+  }).vm.a
+)
 
 // can receive extra props
 // ideally, it should not
@@ -45,12 +45,12 @@ const AppWithProps = {
   template: ''
 }
 
-// accept props
-wrapper = mount(AppWithProps, {
-  props: { a: 'Hello' }
-})
-// vm is properly typed
-expectType<string>(wrapper.vm.a)
+// accept props - vm is properly typed
+expectType<string>(
+  mount(AppWithProps, {
+    props: { a: 'Hello' }
+  }).vm.a
+)
 
 // can't receive extra props
 expectError(
@@ -71,18 +71,33 @@ const AppWithArrayProps = {
   template: ''
 }
 
-// accept props
-wrapper = mount(AppWithArrayProps, {
-  props: { a: 'Hello' }
-})
-// vm is properly typed
-expectType<string>(wrapper.vm.a)
+// accept props - vm is properly typed
+expectType<string>(
+  mount(AppWithArrayProps, {
+    props: { a: 'Hello' }
+  }).vm.a
+)
 
 // can receive extra props
 // as they are declared as `string[]`
 mount(AppWithArrayProps, {
   props: { a: 'Hello', b: 2 }
 })
+
+// cannot receive extra props
+// if they pass use object inside
+expectError(
+  mount(
+    {
+      props: ['a']
+    },
+    {
+      props: {
+        b: 2
+      }
+    }
+  )
+)
 
 const AppWithoutProps = {
   template: ''

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -116,9 +116,9 @@ const AppWithoutProps = {
 
 // can't receive extra props
 expectError(
-  (wrapper = mount(AppWithoutProps, {
+  mount(AppWithoutProps, {
     props: { b: 'Hello' }
-  }))
+  })
 )
 
 // except if explicitly cast

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -20,6 +20,17 @@ expectType<string>(
   }).vm.a
 )
 
+// no data provided
+expectError(
+  mount(AppWithDefine, {
+    data() {
+      return {
+        myVal: 1
+      }
+    }
+  })
+)
+
 // can receive extra props
 // ideally, it should not
 // but the props have type { a: string } & VNodeProps


### PR DESCRIPTION
This improves typing when using 

```ts
mount({
 props: {
   // ...
  }
})
```

and also adds the data type validation
```ts
const AppWithDefine = defineComponent({
  props: {
    a: {
      type: String,
      required: true
    },
    b: Number
  },
  template: ''
})



// no data provided
expectError(
  mount(AppWithDefine, {
    data() {
      return {
        myVal: 1
      }
    }
  })
)
```