### PR TITLE
fix: bundle dependencies inline and fix es build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vue/compiler-sfc": "^3.0.0-beta.10",
     "babel-jest": "^25.2.3",
     "babel-preset-jest": "^25.2.1",
+    "dom-event-types": "^1.0.0",
     "flush-promises": "^1.0.2",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
@@ -45,8 +46,8 @@
     "vuex": "^4.0.0-beta.1"
   },
   "peerDependencies": {
-    "@vue/compiler-sfc": "^3.0.0-beta.10",
     "@vue/compiler-dom": "^3.0.0-beta.10",
+    "@vue/compiler-sfc": "^3.0.0-beta.10",
     "vue": "^3.0.0-beta.10"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "README.md",
     "dist/index.d.ts"
   ],
-  "dependencies": {
-    "dom-event-types": "^1.0.0",
-    "lodash": "^4.17.15"
-  },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.8.4",
@@ -28,6 +24,7 @@
     "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.149",
     "@types/node": "12.12.35",
+    "@vue/compiler-dom": "^3.0.0-beta.10",
     "@vue/compiler-sfc": "^3.0.0-beta.10",
     "babel-jest": "^25.2.3",
     "babel-preset-jest": "^25.2.1",
@@ -49,6 +46,7 @@
   },
   "peerDependencies": {
     "@vue/compiler-sfc": "^3.0.0-beta.10",
+    "@vue/compiler-dom": "^3.0.0-beta.10",
     "vue": "^3.0.0-beta.10"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue/test-utils",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-alpha.4",
   "license": "MIT",
   "main": "dist/vue-test-utils.cjs.js",
   "browser": "dist/vue-test-utils.browser.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,8 +25,7 @@ function createEntry(options) {
     input,
     external: [
       'vue',
-      'lodash/mergeWith',
-      'lodash/isString'
+      '@vue/compiler-dom'
     ],
     plugins: [
       replace({
@@ -41,14 +40,11 @@ function createEntry(options) {
       format,
       globals: {
         vue: 'Vue',
+        '@vue/compiler-dom': 'VueCompilerDOM',
         'lodash/mergeWith': '_.mergeWith',
         'lodash/isString': '_.isString',
       }
     }
-  }
-
-  if (['es', 'cjs'].includes(format)) {
-    config.external.push('dom-event-types')
   }
 
   if (format === 'es') {
@@ -57,7 +53,7 @@ function createEntry(options) {
   if (format === 'cjs') {
     config.output.file = pkg.main
   }
-  console.log('file is', config.output.file)
+  console.log(`Building ${format}: ${config.output.file}`)
 
   config.plugins.push(
     ts({
@@ -78,7 +74,6 @@ function createEntry(options) {
 
 export default [
   createEntry({ format: 'es', input: 'src/index.ts', isBrowser: false }),
-  createEntry({ format: 'es', input: 'src/index.ts', isBrowser: true }),
   createEntry({ format: 'iife', input: 'src/index.ts', isBrowser: true }),
   createEntry({ format: 'cjs', input: 'src/index.ts', isBrowser: false }),
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,7 @@ function createEntry(options) {
   }
 
   if (format === 'es') {
-    config.output.file = isBrowser ? pkg.browser : pkg.module
+    config.output.file = pkg.module
   }
   if (format === 'cjs') {
     config.output.file = pkg.main
@@ -58,7 +58,7 @@ function createEntry(options) {
       check: format === 'es' && isBrowser,
       tsconfigOverride: {
         compilerOptions: {
-          declaration: format === 'es' && isBrowser,
+          declaration: format === 'es',
           target: 'es5', // not sure what this should be?
           module: format === 'cjs' ? 'es2015' : 'esnext'
         },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,9 +40,7 @@ function createEntry(options) {
       format,
       globals: {
         vue: 'Vue',
-        '@vue/compiler-dom': 'VueCompilerDOM',
-        'lodash/mergeWith': '_.mergeWith',
-        'lodash/isString': '_.isString',
+        '@vue/compiler-dom': 'VueCompilerDOM'
       }
     }
   }

--- a/src/create-dom-event.ts
+++ b/src/create-dom-event.ts
@@ -1,4 +1,4 @@
-import * as eventTypes from 'dom-event-types'
+import eventTypes from 'dom-event-types'
 
 interface TriggerOptions {
   code?: String

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -124,6 +124,9 @@ export function mount(
     ref: MOUNT_COMPONENT_REF
   })
 
+  const global = mergeGlobalProperties(config.global, options?.global)
+  component.components = { ...component.components, ...global.components }
+
   // create the wrapper component
   const Parent = defineComponent({
     name: MOUNT_PARENT_NAME,
@@ -142,7 +145,6 @@ export function mount(
 
   // create the app
   const app = createApp(Parent)
-  const global = mergeGlobalProperties(config.global, options?.global)
 
   // global mocks mixin
   if (global?.mocks) {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -175,9 +175,8 @@ export function mount(
   }
 
   if (global?.components) {
-    for (const key of Object.keys(global.components)) {
+    for (const key of Object.keys(global.components))
       app.component(key, global.components[key])
-    }
   }
 
   if (global?.directives) {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -175,8 +175,9 @@ export function mount(
   }
 
   if (global?.components) {
-    for (const key of Object.keys(global.components))
+    for (const key of Object.keys(global.components)) {
       app.component(key, global.components[key])
+    }
   }
 
   if (global?.directives) {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -160,34 +160,34 @@ export function mount(
   }
 
   // AppConfig
-  if (global?.config) {
+  if (global.config) {
     for (const [k, v] of Object.entries(global.config)) {
       app.config[k] = v
     }
   }
 
   // use and plugins from mounting options
-  if (global?.plugins) {
+  if (global.plugins) {
     for (const use of global.plugins) app.use(use)
   }
 
   // use any mixins from mounting options
-  if (global?.mixins) {
+  if (global.mixins) {
     for (const mixin of global.mixins) app.mixin(mixin)
   }
 
-  if (global?.components) {
+  if (global.components) {
     for (const key of Object.keys(global.components))
       app.component(key, global.components[key])
   }
 
-  if (global?.directives) {
+  if (global.directives) {
     for (const key of Object.keys(global.directives))
       app.directive(key, global.directives[key])
   }
 
   // provide any values passed via provides mounting option
-  if (global?.provide) {
+  if (global.provide) {
     for (const key of Reflect.ownKeys(global.provide)) {
       // @ts-ignore: https://github.com/microsoft/TypeScript/issues/1863
       app.provide(key, global.provide[key])
@@ -198,8 +198,8 @@ export function mount(
   app.mixin(attachEmitListener())
 
   // stubs
-  if (options?.global?.stubs || options?.shallow) {
-    stubComponents(options?.global?.stubs, options?.shallow)
+  if (global.stubs || options?.shallow) {
+    stubComponents(global.stubs, options?.shallow)
   } else {
     transformVNodeArgs()
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,29 +2,33 @@ import { GlobalMountOptions } from './types'
 
 const isString = (val: unknown): val is string => typeof val === 'string'
 
-// Deep merge function, adapted from from https://gist.github.com/ahtcx/0cd94e62691f539160b32ecda18af3d6
-// Merge a `source` object to a `target` recursively
-const merge = (target: object, source: object) => {
-  // Iterate through `source` properties and if an `Object` set property to merge of `target` and `source` properties
-  for (const key of Object.keys(source)) {
-    if (!target[key]) {
-      target[key] = source[key]
-    } else {
-      if (source[key] instanceof Object) {
-        Object.assign(source[key], merge(target[key], source[key]))
-      }
-    }
-  }
-
-  Object.assign(target || {}, source)
-}
-
 function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
-  merge(configGlobal, mountGlobal)
-  return configGlobal
+  const {
+    mixins: configMixins = [],
+    plugins: configPlugins = [],
+    ...configRest
+  } = configGlobal
+  const {
+    mixins: mountMixins = [],
+    plugins: mountPlugins = [],
+    ...mountRest
+  } = mountGlobal
+  const mixins = [...configMixins, ...mountMixins]
+  const plugins = [...configPlugins, ...mountPlugins]
+
+  return {
+    mixins,
+    plugins,
+    components: { ...configRest.components, ...mountRest.components },
+    provide: { ...configRest.provide, ...mountRest.provide },
+    mocks: { ...configRest.mocks, ...mountRest.mocks },
+    config: { ...configRest.config, ...mountRest.config },
+    directives: { ...configRest.directives, ...mountRest.directives },
+    stubs: { ...configRest.stubs, ...mountRest.stubs }
+  }
 }
 
 export { isString, mergeGlobalProperties }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,63 @@
-import isString from 'lodash/isString'
 import mergeWith from 'lodash/mergeWith'
 
 import { GlobalMountOptions } from './types'
+
+const isString = (val: unknown): val is string => typeof val === 'string'
+
+function deepMerge(...objects: object[]) {
+  const isObject = (obj: any) => obj && typeof obj === 'object'
+
+  function deepMergeInner(target: object, source: object) {
+    Object.keys(source).forEach((key: string) => {
+      const targetValue = target[key]
+      const sourceValue = source[key]
+
+      if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
+        target[key] = targetValue.concat(sourceValue)
+      } else if (isObject(targetValue) && isObject(sourceValue)) {
+        target[key] = deepMergeInner(
+          Object.assign({}, targetValue),
+          sourceValue
+        )
+      } else {
+        target[key] = sourceValue
+      }
+    })
+
+    return target
+  }
+
+  if (objects.length < 2) {
+    throw new Error(
+      'deepMerge: this function expects at least 2 objects to be provided'
+    )
+  }
+
+  if (objects.some((object) => !isObject(object))) {
+    throw new Error('deepMerge: all values should be of type "object"')
+  }
+
+  const target = objects.shift()
+  let source: object
+
+  while ((source = objects.shift())) {
+    deepMergeInner(target, source)
+  }
+
+  return target
+}
 
 function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
+  // const merged: GlobalMountOptions = deepMerge(configGlobal, mountGlobal)
+  // merged.components = {
+  //   ...mountGlobal.components,
+  //   ...configGlobal.components
+  // }
+  // console.log(merged)
+  // return merged
   return mergeWith(
     {},
     configGlobal,
@@ -24,6 +75,7 @@ function mergeGlobalProperties(
       }
     }
   )
+  // return mountGlobal
 }
 
 export { isString, mergeGlobalProperties }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,51 +6,36 @@ function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
-  const {
-    mixins: configMixins = [],
-    plugins: configPlugins = [],
-    ...configRest
-  } = configGlobal
-  const {
-    mixins: mountMixins = [],
-    plugins: mountPlugins = [],
-    ...mountRest
-  } = mountGlobal
-  const mixins = [...configMixins, ...mountMixins]
-  const plugins = [...configPlugins, ...mountPlugins]
-
   const stubs: Record<string, any> = {}
-
-  if (configRest.stubs) {
-    if (Array.isArray(configRest.stubs)) {
-      configRest.stubs.forEach((x) => (stubs[x] = true))
+  if (configGlobal.stubs) {
+    if (Array.isArray(configGlobal.stubs)) {
+      configGlobal.stubs.forEach((x) => (stubs[x] = true))
     } else {
-      for (const [k, v] of Object.entries(configRest.stubs)) {
+      for (const [k, v] of Object.entries(configGlobal.stubs)) {
         stubs[k] = v
       }
     }
   }
 
-  if (mountRest.stubs) {
-    if (mountRest.stubs && Array.isArray(mountRest.stubs)) {
-      mountRest.stubs.forEach((x) => (stubs[x] = true))
+  if (mountGlobal.stubs) {
+    if (mountGlobal.stubs && Array.isArray(mountGlobal.stubs)) {
+      mountGlobal.stubs.forEach((x) => (stubs[x] = true))
     } else {
-      for (const [k, v] of Object.entries(mountRest.stubs)) {
+      for (const [k, v] of Object.entries(mountGlobal.stubs)) {
         stubs[k] = v
       }
     }
   }
 
   return {
-    mixins,
-    plugins,
+    mixins: [...(configGlobal.mixins || []), ...(mountGlobal.mixins || [])],
+    plugins: [...(configGlobal.plugins || []), ...(mountGlobal.plugins || [])],
     stubs,
-    components: { ...configRest.components, ...mountRest.components },
-    provide: { ...configRest.provide, ...mountRest.provide },
-    mocks: { ...configRest.mocks, ...mountRest.mocks },
-    config: { ...configRest.config, ...mountRest.config },
-    directives: { ...configRest.directives, ...mountRest.directives }
-    // stubs: { configRest.stubs, ...mountRest.stubs }
+    components: { ...configGlobal.components, ...mountGlobal.components },
+    provide: { ...configGlobal.provide, ...mountGlobal.provide },
+    mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
+    config: { ...configGlobal.config, ...mountGlobal.config },
+    directives: { ...configGlobal.directives, ...mountGlobal.directives }
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import mergeWith from 'lodash/mergeWith'
-
 import { GlobalMountOptions } from './types'
 
 const isString = (val: unknown): val is string => typeof val === 'string'
@@ -51,31 +49,7 @@ function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
-  // const merged: GlobalMountOptions = deepMerge(configGlobal, mountGlobal)
-  // merged.components = {
-  //   ...mountGlobal.components,
-  //   ...configGlobal.components
-  // }
-  // console.log(merged)
-  // return merged
-  return mergeWith(
-    {},
-    configGlobal,
-    mountGlobal,
-    (objValue, srcValue, key: keyof GlobalMountOptions) => {
-      switch (key) {
-        case 'mocks':
-        case 'provide':
-        case 'components':
-        case 'directives':
-          return { ...objValue, ...srcValue }
-        case 'plugins':
-        case 'mixins':
-          return [...(objValue || []), ...(srcValue || [])].filter(Boolean)
-      }
-    }
-  )
-  // return mountGlobal
+  return deepMerge(configGlobal, mountGlobal)
 }
 
 export { isString, mergeGlobalProperties }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,30 +2,26 @@ import { GlobalMountOptions } from './types'
 
 const isString = (val: unknown): val is string => typeof val === 'string'
 
+function mergeStubs(target, source) {
+  if (source.stubs) {
+    if (Array.isArray(source.stubs)) {
+      source.stubs.forEach((x) => (target[x] = true))
+    } else {
+      for (const [k, v] of Object.entries(source.stubs)) {
+        target[k] = v
+      }
+    }
+  }
+}
+
 function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): GlobalMountOptions {
   const stubs: Record<string, any> = {}
-  if (configGlobal.stubs) {
-    if (Array.isArray(configGlobal.stubs)) {
-      configGlobal.stubs.forEach((x) => (stubs[x] = true))
-    } else {
-      for (const [k, v] of Object.entries(configGlobal.stubs)) {
-        stubs[k] = v
-      }
-    }
-  }
 
-  if (mountGlobal.stubs) {
-    if (mountGlobal.stubs && Array.isArray(mountGlobal.stubs)) {
-      mountGlobal.stubs.forEach((x) => (stubs[x] = true))
-    } else {
-      for (const [k, v] of Object.entries(mountGlobal.stubs)) {
-        stubs[k] = v
-      }
-    }
-  }
+  mergeStubs(stubs, configGlobal)
+  mergeStubs(stubs, mountGlobal)
 
   return {
     mixins: [...(configGlobal.mixins || []), ...(mountGlobal.mixins || [])],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,15 +19,38 @@ function mergeGlobalProperties(
   const mixins = [...configMixins, ...mountMixins]
   const plugins = [...configPlugins, ...mountPlugins]
 
+  const stubs: Record<string, any> = {}
+
+  if (configRest.stubs) {
+    if (Array.isArray(configRest.stubs)) {
+      configRest.stubs.forEach((x) => (stubs[x] = true))
+    } else {
+      for (const [k, v] of Object.entries(configRest.stubs)) {
+        stubs[k] = v
+      }
+    }
+  }
+
+  if (mountRest.stubs) {
+    if (mountRest.stubs && Array.isArray(mountRest.stubs)) {
+      mountRest.stubs.forEach((x) => (stubs[x] = true))
+    } else {
+      for (const [k, v] of Object.entries(mountRest.stubs)) {
+        stubs[k] = v
+      }
+    }
+  }
+
   return {
     mixins,
     plugins,
+    stubs,
     components: { ...configRest.components, ...mountRest.components },
     provide: { ...configRest.provide, ...mountRest.provide },
     mocks: { ...configRest.mocks, ...mountRest.mocks },
     config: { ...configRest.config, ...mountRest.config },
-    directives: { ...configRest.directives, ...mountRest.directives },
-    stubs: { ...configRest.stubs, ...mountRest.stubs }
+    directives: { ...configRest.directives, ...mountRest.directives }
+    // stubs: { configRest.stubs, ...mountRest.stubs }
   }
 }
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,3 +1,5 @@
+import { h } from 'vue'
+
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
 
@@ -15,16 +17,24 @@ describe('config', () => {
 
   describe('components', () => {
     const Component = {
-      template: '<div>{{ msg }} <hello/></div>',
+      components: { Hello },
+      template: '<div>{{ msg }} <Hello /></div>',
       props: ['msg']
     }
 
     it('allows setting components globally', () => {
-      config.global.components = { Hello }
+      const HelloOverride = {
+        name: 'HelloOverride',
+        props: ['msg'],
+        render() {
+          return () => h('div', `${this.msg} Hello world override`)
+        }
+      }
+      config.global.components = { Hello: HelloOverride }
       const wrapper1 = mount(Component, { props: { msg: 'Wrapper1' } })
       const wrapper2 = mount(Component, { props: { msg: 'Wrapper2' } })
-      expect(wrapper1.text()).toEqual('Wrapper1 Hello world')
-      expect(wrapper2.text()).toEqual('Wrapper2 Hello world')
+      expect(wrapper1.text()).toEqual('Wrapper1 Hello world override')
+      expect(wrapper2.text()).toEqual('Wrapper2 Hello world override')
     })
 
     it('allows overwriting globally set component config on a per mount instance', () => {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -12,6 +12,8 @@ describe('config', () => {
       mocks: undefined,
       provide: undefined
     }
+
+    jest.clearAllMocks()
   })
 
   describe('components', () => {
@@ -103,6 +105,48 @@ describe('config', () => {
       expect(
         mount(Component, { global: { mocks: { foo: 'baz' } } }).text()
       ).toEqual('baz')
+    })
+  })
+
+  describe('mixins', () => {
+    const createdHook = jest.fn()
+    const mixin = {
+      created() {
+        createdHook()
+      }
+    }
+    const Component = {
+      render() {
+        return h('div')
+      }
+    }
+
+    it('sets a mixin everywhere', () => {
+      config.global.mixins = [mixin]
+      mount(Component)
+
+      // once on root, once in the mounted component
+      expect(createdHook).toHaveBeenCalledTimes(2)
+    })
+
+    it('concats with locally defined mixins', () => {
+      config.global.mixins = [mixin]
+      const localHook = jest.fn()
+      const localMixin = {
+        created() {
+          localHook(this.$options.name)
+        }
+      }
+
+      mount(Component, {
+        global: {
+          mixins: [localMixin]
+        }
+      })
+
+      // once on root, once in the mounted component
+      expect(localHook).toHaveBeenCalledTimes(2)
+      expect(createdHook).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -109,9 +109,6 @@ describe('config', () => {
   })
 
   describe('provide', () => {
-    config.global.provide = {
-      theme: 'dark'
-    }
     const Comp = {
       setup() {
         const theme = inject('theme')
@@ -120,11 +117,17 @@ describe('config', () => {
     }
 
     it('sets a provide everywhere', () => {
+      config.global.provide = {
+        theme: 'dark'
+      }
       const wrapper = mount(Comp)
       expect(wrapper.html()).toContain('dark')
     })
 
     it('overrides with a local provide', () => {
+      config.global.provide = {
+        theme: 'dark'
+      }
       const wrapper = mount(Comp, {
         global: {
           provide: {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { h, inject } from 'vue'
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
 
@@ -108,6 +108,44 @@ describe('config', () => {
     })
   })
 
+  describe('provide', () => {
+    it('sets a provide everywhere', () => {
+      config.global.provide = {
+        theme: 'dark'
+      }
+      const Comp = {
+        setup() {
+          const theme = inject('theme')
+          return () => h('div', theme)
+        }
+      }
+
+      const wrapper = mount(Comp)
+      expect(wrapper.html()).toContain('dark')
+    })
+
+    it('overrides with a local provide', () => {
+      config.global.provide = {
+        theme: 'dark'
+      }
+      const Comp = {
+        setup() {
+          const theme = inject('theme')
+          return () => h('div', theme)
+        }
+      }
+
+      const wrapper = mount(Comp, {
+        global: {
+          provide: {
+            theme: 'light'
+          }
+        }
+      })
+      expect(wrapper.html()).toContain('light')
+    })
+  })
+
   describe('mixins', () => {
     const createdHook = jest.fn()
     const mixin = {
@@ -147,6 +185,60 @@ describe('config', () => {
       // once on root, once in the mounted component
       expect(localHook).toHaveBeenCalledTimes(2)
       expect(createdHook).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('stubs', () => {
+    const Foo = {
+      name: 'Foo',
+      render() {
+        return h('div', 'real foo')
+      }
+    }
+
+    const Component = {
+      render() {
+        return h('div', h(Foo))
+      }
+    }
+
+    it('sets a stub globally', () => {
+      config.global.stubs = {
+        Foo: {
+          render() {
+            return h('div', 'foo stub')
+          }
+        }
+      }
+
+      const wrapper = mount(Component)
+
+      // once on root, once in the mounted component
+      expect(wrapper.html()).toContain('foo stub')
+    })
+
+    xit('overrides config stub with locally defined stub', () => {
+      config.global.stubs = {
+        Foo: {
+          render() {
+            return h('div', 'config foo stub')
+          }
+        }
+      }
+
+      const wrapper = mount(Component, {
+        global: {
+          stubs: {
+            Foo: {
+              render() {
+                return h('div', 'local foo stub')
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.html()).toContain('local foo stub')
     })
   })
 })

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
 
@@ -13,7 +14,7 @@ describe('config', () => {
     }
   })
 
-  describe.skip('components', () => {
+  describe('components', () => {
     const Component = {
       components: { Hello },
       template: '<div>{{ msg }} <Hello /></div>',
@@ -22,22 +23,23 @@ describe('config', () => {
 
     it('allows setting components globally', () => {
       const HelloLocal = {
-        props: ['msg'],
-        template: '<div>{{ msg }}</div>'
+        name: 'Hello',
+        render() {
+          return h('div', 'Hello Local')
+        }
       }
       config.global.components = { Hello: HelloLocal }
       const wrapper1 = mount(Component, {
-        props: { msg: 'Wrapper1 Overwritten' }
+        props: { msg: 'Wrapper1' }
       })
       const wrapper2 = mount(Component, {
-        props: { msg: 'Wrapper2 Overwritten' }
+        props: { msg: 'Wrapper2' }
       })
-      expect(wrapper1.text()).toEqual('Wrapper1 Overwritten')
-      expect(wrapper2.text()).toEqual('Wrapper2 Overwritten')
+      expect(wrapper1.text()).toEqual('Wrapper1 Hello Local')
+      expect(wrapper2.text()).toEqual('Wrapper2 Hello Local')
     })
 
     it('allows overwriting globally set component config on a per mount instance', () => {
-      console.log('TODO: Fix this')
       config.global.components = { Hello }
       const HelloLocal = { template: '<div>Hello Overwritten</div>' }
       const wrapper1 = mount(Component, { props: { msg: 'Wrapper1' } })

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -109,32 +109,22 @@ describe('config', () => {
   })
 
   describe('provide', () => {
-    it('sets a provide everywhere', () => {
-      config.global.provide = {
-        theme: 'dark'
+    config.global.provide = {
+      theme: 'dark'
+    }
+    const Comp = {
+      setup() {
+        const theme = inject('theme')
+        return () => h('div', theme)
       }
-      const Comp = {
-        setup() {
-          const theme = inject('theme')
-          return () => h('div', theme)
-        }
-      }
+    }
 
+    it('sets a provide everywhere', () => {
       const wrapper = mount(Comp)
       expect(wrapper.html()).toContain('dark')
     })
 
     it('overrides with a local provide', () => {
-      config.global.provide = {
-        theme: 'dark'
-      }
-      const Comp = {
-        setup() {
-          const theme = inject('theme')
-          return () => h('div', theme)
-        }
-      }
-
       const wrapper = mount(Comp, {
         global: {
           provide: {
@@ -202,30 +192,25 @@ describe('config', () => {
       }
     }
 
-    it('sets a stub globally', () => {
+    beforeEach(() => {
       config.global.stubs = {
         Foo: {
-          render() {
-            return h('div', 'foo stub')
-          }
-        }
-      }
-
-      const wrapper = mount(Component)
-
-      // once on root, once in the mounted component
-      expect(wrapper.html()).toContain('foo stub')
-    })
-
-    xit('overrides config stub with locally defined stub', () => {
-      config.global.stubs = {
-        Foo: {
+          name: 'Foo',
           render() {
             return h('div', 'config foo stub')
           }
         }
       }
+    })
 
+    it('sets a stub globally', () => {
+      const wrapper = mount(Component)
+
+      // once on root, once in the mounted component
+      expect(wrapper.html()).toContain('config foo stub')
+    })
+
+    it('overrides config stub with locally defined stub', () => {
       const wrapper = mount(Component, {
         global: {
           stubs: {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -15,7 +15,7 @@ describe('config', () => {
     }
   })
 
-  describe('components', () => {
+  describe.skip('components', () => {
     const Component = {
       components: { Hello },
       template: '<div>{{ msg }} <Hello /></div>',
@@ -23,6 +23,7 @@ describe('config', () => {
     }
 
     it('allows setting components globally', () => {
+      console.log('TODO: Fix this')
       const HelloOverride = {
         name: 'HelloOverride',
         props: ['msg'],
@@ -38,6 +39,7 @@ describe('config', () => {
     })
 
     it('allows overwriting globally set component config on a per mount instance', () => {
+      console.log('TODO: Fix this')
       config.global.components = { Hello }
       const HelloLocal = { template: '<div>Hello Overwritten</div>' }
       const wrapper1 = mount(Component, { props: { msg: 'Wrapper1' } })

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -26,7 +26,7 @@ describe('shallowMount', () => {
     )
   })
 
-  it('stubs all components, but allows providing custom stub', () => {
+  it.only('stubs all components, but allows providing custom stub', () => {
     const wrapper = mount(ComponentWithChildren, {
       shallow: true,
       global: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.0-beta.10":
+"@vue/compiler-dom@3.0.0-beta.10", "@vue/compiler-dom@^3.0.0-beta.10":
   version "3.0.0-beta.10"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.10.tgz#5b35df447eb96cb7faed37b76a8a9aca71a87c67"
   integrity sha512-S1Qqc74Hc3BnHjORzWJvG4Fj5B4O8aqTF1Oyd+Px65CB6qkbAaqTLneYnM5by/78j8inmt4FCHOf48L+gzChRA==
@@ -2219,11 +2219,6 @@ dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
-
-dom-event-types@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
-  integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
 
 domexception@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,11 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+dom-event-types@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
+  integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"


### PR DESCRIPTION
As pointed about by @JessicaSachs, our es build was depending on cjs dependencies.

Although I like the idea of only shipping our code and asking the users to install dependencies like lodash, it does add a bit of complexity. Eg, depending if you are using VTU in a browser/node/es build, you need to include dependencies differently.

In this PR, we now inline some dependencies:

- `lodash/isString`, `lodash/mergeWith`
- `eventTypes` (for `trigger`)

Vue and compiler-sfc and compiler-dom are still peer dependencies, so the user will bring their own version of those.

This does increase the bundle size - from 900 lines to around 4000. That said, mostly you will not be shipping this library to users, and 4000 lines is before minify, so it could be smaller, if the user wants to make it smaller, so I think this trade-off is probably fine. Simple is best!

For comparison, VTU v1 is around 10k lines (also not minified).