### PR TITLE
fix: add slot dictionary type as typescript string index assignment workaround

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -29,13 +29,16 @@ import { stubComponents } from './stubs'
 
 type Slot = VNode | string | { render: Function }
 
+type SlotDictionary = {
+  [key: string]: Slot
+}
+
 interface MountingOptions<Props> {
   data?: () => Record<string, unknown>
   props?: Props
   attrs?: Record<string, unknown>
-  slots?: {
+  slots?: SlotDictionary & {
     default?: Slot
-    [key: string]: Slot
   }
   global?: GlobalMountOptions
   attachTo?: HTMLElement | string


### PR DESCRIPTION
This PR addresses the second error in #61:

```
error  in /Users/ced-pro/Code/vtu-next-test/node_modules/@vue/test-utils/dist/mount.d.ts

ERROR in /Users/ced-pro/Code/vtu-next-test/node_modules/@vue/test-utils/dist/mount.d.ts(9,9):
9:9 Property 'default' of type 'string | VNode<RendererNode, RendererElement> | { render: Function; } | undefined' is not assignable to string index type 'Slot'.
    7 |     props?: Record<string, any>;
    8 |     slots?: {
 >  9 |         default?: Slot;
      |         ^
   10 |         [key: string]: Slot;
   11 |     };
   12 |     global?: {
```

From [this SO thread](https://stackoverflow.com/a/45261035/3366431):

> TypeScript interfaces do not have an "`additionalProperties`" mechanism like JSON Schema does.


Here's a minimal reproduction in TypeScript to help illustrate the problem:

```typescript
// old implementation
interface OldType {
  default?: number;
  [key: string]: number;
}

const o: OldType = {
  foo: 3,
  bar: 4,
  default: 5
} // breaks

// new implementation
type NumDict = {
  [key: string]: number;
}
type Num = {
  default?: number;
}

const n: NumDict & Num = {
  foo: 3,
  bar: 4,
  default: 5
} // works
```

When run with [`ts-node`](https://github.com/TypeStrong/ts-node), only the implementation for `o: OldType` throws an error:
```
$ ts-node node.ts                                                                                                                                                                       

/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:434
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
node.ts:2:3 - error TS2411: Property 'default' of type 'number | undefined' is not assignable to string index type 'number'.

2   default?: number;
    ~~~~~~~

    at createTSError (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:434:12)
    at reportTSError (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:438:19)
    at getOutput (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:578:36)
    at Object.compile (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:775:32)
    at Module.m._compile (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:858:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:1196:10)
    at Object.require.extensions.<computed> [as .ts] (/home/seevee/.nvm/versions/node/v14.1.0/lib/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (internal/modules/cjs/loader.js:1040:32)
    at Function.Module._load (internal/modules/cjs/loader.js:929:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```