### PR TITLE
types: fix typing for options.attachTo

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -89,15 +89,15 @@ export function mount(
     let to: Element
     if (typeof options.attachTo === 'string') {
       to = document.querySelector(options.attachTo)
+      if (!to) {
+        throw new Error(
+          `Unable to find the element matching the selector ${options.attachTo} given as the \`attachTo\` option`
+        )
+      }
     } else {
       to = options.attachTo
     }
 
-    if (!to) {
-      throw new Error(
-        `Unable to find the element matching the selector ${options.attachTo} given as the \`attachTo\` option`
-      )
-    }
     to.appendChild(el)
   }
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -86,9 +86,12 @@ export function mount(
   el.id = MOUNT_ELEMENT_ID
 
   if (options?.attachTo) {
-    const to = isString(options.attachTo)
-      ? document.querySelector(options.attachTo)
-      : options.attachTo
+    let to: Element
+    if (typeof options.attachTo === 'string') {
+      to = document.querySelector(options.attachTo)
+    } else {
+      to = options.attachTo
+    }
 
     if (!to) {
       throw new Error(


### PR DESCRIPTION
Running `yarn test` on master fails by TS compilation errors. 🤔 

Fixed, not sure how this got introduced.