### PR TITLE
fix: esm build support by inlining @vue/shared utility functions

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,5 +1,5 @@
 import { transformVNodeArgs, h, createVNode } from 'vue'
-import { hyphenate } from '@vue/shared'
+import { hyphenate } from './utils/vueShared'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { config } from './config'
 import { matchName } from './utils/matchName'

--- a/src/utils/matchName.ts
+++ b/src/utils/matchName.ts
@@ -1,4 +1,4 @@
-import { camelize, capitalize } from '@vue/shared'
+import { camelize, capitalize } from './vueShared'
 
 export function matchName(target, sourceName) {
   const camelized = camelize(target)

--- a/src/utils/vueShared.ts
+++ b/src/utils/vueShared.ts
@@ -1,0 +1,35 @@
+const cacheStringFunction = <T extends (str: string) => string>(fn: T): T => {
+  const cache: Record<string, string> = Object.create(null)
+  return ((str: string) => {
+    const hit = cache[str]
+    return hit || (cache[str] = fn(str))
+  }) as any
+}
+
+const camelizeRE = /-(\w)/g
+export const camelize = cacheStringFunction((str: string): string => {
+  return str.replace(camelizeRE, (_, c) => (c ? c.toUpperCase() : ''))
+})
+
+export const capitalize = cacheStringFunction((str: string): string => {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+})
+
+const hyphenateRE = /\B([A-Z])/g
+export const hyphenate = cacheStringFunction((str: string): string => {
+  return str.replace(hyphenateRE, '-$1').toLowerCase()
+})
+
+export const enum ShapeFlags {
+  ELEMENT = 1,
+  FUNCTIONAL_COMPONENT = 1 << 1,
+  STATEFUL_COMPONENT = 1 << 2,
+  TEXT_CHILDREN = 1 << 3,
+  ARRAY_CHILDREN = 1 << 4,
+  SLOTS_CHILDREN = 1 << 5,
+  TELEPORT = 1 << 6,
+  SUSPENSE = 1 << 7,
+  COMPONENT_SHOULD_KEEP_ALIVE = 1 << 8,
+  COMPONENT_KEPT_ALIVE = 1 << 9,
+  COMPONENT = ShapeFlags.STATEFUL_COMPONENT | ShapeFlags.FUNCTIONAL_COMPONENT
+}

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -1,5 +1,5 @@
 import { ComponentPublicInstance, nextTick, App } from 'vue'
-import { ShapeFlags } from '@vue/shared'
+import { ShapeFlags } from './utils/vueShared'
 import { config } from './config'
 
 import { DOMWrapper } from './dom-wrapper'


### PR DESCRIPTION
Currently @vue/shared is an internal library that doesn't support browser usage. We only depend on it for some string utility functions and the ShapeFlag type.

We will revisit if @vue/shared will eventually ship a dist'd es build that is browser compatible. Until then, this will make Vue Test Utils ES compatible