### PR TITLE
chore: typings maintenance in mount

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type FindAllComponentsSelector = NameSelector | string
 
 export type GlobalMountOptions = {
   plugins?: Plugin[]
-  config?: AppConfig
+  config?: Omit<AppConfig, 'isNativeTag'> // isNativeTag is readonly, so we omit it
   mixins?: ComponentOptions[]
   mocks?: Record<string, any>
   provide?: Record<any, any>


### PR DESCRIPTION
This commit tidies up the types in mount. The goal is to enable `strict: true` in the future on the project, and this commit fixes up a bunch of errors that the strict mode complains about.

The only change for VTU users is that `GlobalMountOptions.config` now does not allow to override `isNativeTag` as it is private and readonly in `AppConfig`: https://github.com/vuejs/vue-next/blob/71a942b25a2cad61c3d670075523c31d296c7089/packages/runtime-core/src/apiCreateApp.ts#L46-L48 