### PR TITLE
chore: shallowMount overloads

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -245,41 +245,6 @@ export function mount(
   return createWrapper(app, App, setProps)
 }
 
-// Functional component
-export function shallowMount<TestedComponent extends FunctionalComponent>(
-  originalComponent: TestedComponent,
-  options?: MountingOptions<any>
-): VueWrapper<ComponentPublicInstance>
-// Component declared with defineComponent
-export function shallowMount<TestedComponent extends ComponentPublicInstance>(
-  originalComponent: { new (): TestedComponent } & Component,
-  options?: MountingOptions<TestedComponent['$props']>
-): VueWrapper<TestedComponent>
-// Component declared with { props: { ... } }
-export function shallowMount<
-  TestedComponent extends ComponentOptionsWithObjectProps
->(
-  originalComponent: TestedComponent,
-  options?: MountingOptions<ExtractPropTypes<TestedComponent['props'], false>>
-): VueWrapper<ExtractComponent<TestedComponent>>
-// Component declared with { props: [] }
-export function shallowMount<
-  TestedComponent extends ComponentOptionsWithArrayProps
->(
-  originalComponent: TestedComponent,
-  options?: MountingOptions<Record<string, any>>
-): VueWrapper<ExtractComponent<TestedComponent>>
-// Component declared with no props
-export function shallowMount<
-  TestedComponent extends ComponentOptionsWithoutProps,
-  ComponentT extends ComponentOptionsWithoutProps & {}
->(
-  originalComponent: ComponentT extends { new (): any } ? never : ComponentT,
-  options?: MountingOptions<never>
-): VueWrapper<ExtractComponent<TestedComponent>>
-export function shallowMount(
-  originalComponent: any,
-  options?: MountingOptions<any>
-) {
-  return mount(originalComponent, { ...options, shallow: true })
+export const shallowMount: typeof mount = (component: any, options?: any) => {
+  return mount(component, { ...options, shallow: true })
 }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -245,8 +245,40 @@ export function mount(
   return createWrapper(app, App, setProps)
 }
 
+// Functional component
+export function shallowMount<TestedComponent extends FunctionalComponent>(
+  originalComponent: TestedComponent,
+  options?: MountingOptions<any>
+): VueWrapper<ComponentPublicInstance>
+// Component declared with defineComponent
+export function shallowMount<TestedComponent extends ComponentPublicInstance>(
+  originalComponent: { new (): TestedComponent } & Component,
+  options?: MountingOptions<TestedComponent['$props']>
+): VueWrapper<TestedComponent>
+// Component declared with { props: { ... } }
+export function shallowMount<
+  TestedComponent extends ComponentOptionsWithObjectProps
+>(
+  originalComponent: TestedComponent,
+  options?: MountingOptions<ExtractPropTypes<TestedComponent['props'], false>>
+): VueWrapper<ExtractComponent<TestedComponent>>
+// Component declared with { props: [] }
+export function shallowMount<
+  TestedComponent extends ComponentOptionsWithArrayProps
+>(
+  originalComponent: TestedComponent,
+  options?: MountingOptions<Record<string, any>>
+): VueWrapper<ExtractComponent<TestedComponent>>
+// Component declared with no props
+export function shallowMount<
+  TestedComponent extends ComponentOptionsWithoutProps,
+  ComponentT extends ComponentOptionsWithoutProps & {}
+>(
+  originalComponent: ComponentT extends { new (): any } ? never : ComponentT,
+  options?: MountingOptions<never>
+): VueWrapper<ExtractComponent<TestedComponent>>
 export function shallowMount(
-  originalComponent,
+  originalComponent: any,
   options?: MountingOptions<any>
 ) {
   return mount(originalComponent, { ...options, shallow: true })

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -1,0 +1,101 @@
+import { expectError, expectType } from 'tsd'
+import { defineComponent } from 'vue'
+import { shallowMount } from '../src'
+
+const AppWithDefine = defineComponent({
+  props: {
+    a: {
+      type: String,
+      required: true
+    },
+    b: Number
+  },
+  template: ''
+})
+
+// accept props
+let wrapper = shallowMount(AppWithDefine, {
+  props: { a: 'Hello', b: 2 }
+})
+// vm is properly typed
+expectType<string>(wrapper.vm.a)
+
+// can receive extra props
+// ideally, it should not
+// but the props have type { a: string } & VNodeProps
+// which allows any property
+shallowMount(AppWithDefine, {
+  props: { a: 'Hello', c: 2 }
+})
+
+// wrong prop type should not compile
+expectError(
+  shallowMount(AppWithDefine, {
+    props: { a: 2 }
+  })
+)
+
+const AppWithProps = {
+  props: {
+    a: {
+      type: String,
+      required: true
+    }
+  },
+  template: ''
+}
+
+// accept props
+wrapper = shallowMount(AppWithProps, {
+  props: { a: 'Hello' }
+})
+// vm is properly typed
+expectType<string>(wrapper.vm.a)
+
+// can't receive extra props
+expectError(
+  shallowMount(AppWithProps, {
+    props: { a: 'Hello', b: 2 }
+  })
+)
+
+// wrong prop type should not compile
+expectError(
+  shallowMount(AppWithProps, {
+    props: { a: 2 }
+  })
+)
+
+const AppWithArrayProps = {
+  props: ['a'],
+  template: ''
+}
+
+// accept props
+wrapper = shallowMount(AppWithArrayProps, {
+  props: { a: 'Hello' }
+})
+// vm is properly typed
+expectType<string>(wrapper.vm.a)
+
+// can receive extra props
+// as they are declared as `string[]`
+shallowMount(AppWithArrayProps, {
+  props: { a: 'Hello', b: 2 }
+})
+
+const AppWithoutProps = {
+  template: ''
+}
+
+// can't receive extra props
+expectError(
+  (wrapper = shallowMount(AppWithoutProps, {
+    props: { b: 'Hello' }
+  }))
+)
+
+// except if explicitly cast
+shallowMount(AppWithoutProps, {
+  props: { b: 'Hello' } as never
+})


### PR DESCRIPTION
`shallowMount` now has the same signatures than `mount`, to which it delegates the heavy work.