### PR TITLE
chore(config): proper typings for plugins

### DIFF
--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -69,7 +69,7 @@ describe('Plugin', () => {
       it.each(plugins)(
         'Calling install with %p is handled gracefully',
         (plugin) => {
-          config.plugins.VueWrapper.install(plugin)
+          config.plugins.VueWrapper.install(plugin as any)
           expect(() => mountComponent()).not.toThrow()
         }
       )


### PR DESCRIPTION
Adds typings to plugins, still in the quest for switching the TS config to `strict`