### PR TITLE
chore: @vue/compiler-sfc is not a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@vue/compiler-dom": "^3.0.0-beta.12",
-    "@vue/compiler-sfc": "^3.0.0-beta.12",
     "vue": "^3.0.0-beta.12"
   },
   "author": {


### PR DESCRIPTION
If I'm not mistaken, `@vue/compiler-sfc` is never used in this codebase.
It seems to be a peer dependency of vue-jest v5 (but somehow not explicitly specified).

But as this library is framework agnostic, the peer dependency of `vue-jest` should not imply a peer dependency of the library. For users who don't need to test `.vue` files, `@vue/compiler-sfc` is extraneous.