### PR TITLE
Repro: add failing types test for wrapper.vm.$emit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare module '*.vue' {
+  export default any
+}

--- a/test-dts/wrapper.d-test.ts
+++ b/test-dts/wrapper.d-test.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd'
 import { defineComponent } from 'vue'
 import { mount } from '../src'
+import Hello from '../tests/components/Hello.vue'
 
 const AppWithDefine = defineComponent({
   template: ''
@@ -111,3 +112,6 @@ expectType<boolean>(domWrapper.classes('class'))
 // props
 expectType<{ [key: string]: any }>(wrapper.props())
 expectType<any>(wrapper.props('prop'))
+
+// vm
+expectType<Function>(wrapper.findComponent(Hello).vm.$emit)


### PR DESCRIPTION
Repro #144 

The code works fine if you `@ts-ignore`. Just types.

Any ideas? @pikax @cexbrayat maybe? 🤔 Oddly enough it knows that `emit` exists but does not think it is callable.

`vm.$.emit` is defined and works great, but that is the internal instance.

EDIT: we have this problem in the codebase too: https://github.com/vuejs/vue-test-utils-next/blob/c4787821f100524f195fd2365f42dd816634f07d/src/vue-wrapper.ts#L202