### PR TITLE
repro: beta.16 regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^25.0.0",
     "tsd": "0.11.0",
     "typescript": "^3.7.5",
-    "vue": "^3.0.0-beta.15",
+    "vue": "^3.0.0-beta.16",
     "vue-jest": "vuejs/vue-jest#next",
     "vuex": "^4.0.0-beta.1"
   },

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -75,6 +75,17 @@ export function stubComponents(
   shallow: boolean = false
 ) {
   transformVNodeArgs((args) => {
+    const locallyRegisteredComponents = (args[0] as any).components as
+      | Record<string, VNodeTypes>
+      | undefined
+    if (locallyRegisteredComponents) {
+      for (const registrationName in locallyRegisteredComponents) {
+        const component = locallyRegisteredComponents[registrationName]
+        if (!component['name'] && !component['displayName']) {
+          component['name'] = registrationName
+        }
+      }
+    }
     const [nodeType, props, children, patchFlag, dynamicProps] = args
     const type = nodeType as VNodeTypes
     // args[0] can either be:

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -26,7 +26,7 @@ describe('shallowMount', () => {
     )
   })
 
-  it.only('stubs all components, but allows providing custom stub', () => {
+  it('stubs all components, but allows providing custom stub', () => {
     const wrapper = mount(ComponentWithChildren, {
       shallow: true,
       global: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,14 +1199,14 @@
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
-"@vue/compiler-core@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.15.tgz#8710a8e3ba15ba1a8b62bd17609d26bd27fdcc45"
-  integrity sha512-NLNW7tAMHl8ybRgTPTIWLsi8aXHbFngY2x95eEHAdxhNasTY5NsgmQBBH9TBAUQEn6Wo8ybmuvQoNzgcw979Zg==
+"@vue/compiler-core@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.17.tgz#92d75f5ae7a03c51694f439dc96939bde9a7074e"
+  integrity sha512-UHv7YFUremfSXf3CAeEoRZOX+n26IZQxFRwREw55spoMRjjpNIH+sSLQz3pwgTnClm90GlzRMzOFYTOQrzAnfQ==
   dependencies:
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/shared" "3.0.0-beta.17"
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
@@ -1218,13 +1218,13 @@
     "@vue/compiler-core" "3.0.0-beta.12"
     "@vue/shared" "3.0.0-beta.12"
 
-"@vue/compiler-dom@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.15.tgz#ee6dc9ae1dabb5c5c257d7cc20c5f3e95d5e5f4f"
-  integrity sha512-0qVaCosZ6XrkmlSOndGlNh33JQ2oao82uWxC/qw4QWBGm6a1DcKkZFIZFYLQWg5ZIcSrEQrR1VzUidBaZw9AIg==
+"@vue/compiler-dom@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.17.tgz#fa19ad2391cd78dcae121cfbeacf6cc3ebd4ff20"
+  integrity sha512-wj4egu6KzsJy1EG/MHgbEVfVH8oMIGoFqjwkbCyqE5G0uRPAPi0WYHY5lyjAU2gI7cfGxIcFx7UsWT5D9XH0/g==
   dependencies:
-    "@vue/compiler-core" "3.0.0-beta.15"
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/compiler-core" "3.0.0-beta.17"
+    "@vue/shared" "3.0.0-beta.17"
 
 "@vue/compiler-sfc@^3.0.0-beta.12":
   version "3.0.0-beta.12"
@@ -1252,28 +1252,28 @@
     "@vue/compiler-dom" "3.0.0-beta.12"
     "@vue/shared" "3.0.0-beta.12"
 
-"@vue/reactivity@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.15.tgz#4ee0942783d7ff09acab5b8755706597ba6234f6"
-  integrity sha512-Xa0LG8RTNlPYsuqOBhhV03xKhMmuSU0vtKXoIi1yxp9gGU7ga/TMmnhELb66AiupiXdLJwRcdv00KhPF/2y0dA==
+"@vue/reactivity@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.17.tgz#582a0650d3ab5aad1cb15e0e4fdea1dbb1732877"
+  integrity sha512-LPpRAEljlrZjTwTmIxZNMePwTOapWXfAcDRMyFJ/L1MGumfyPl1jHflE8upcUKtUWpXt18+MpNywXwskpr4+4w==
   dependencies:
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/shared" "3.0.0-beta.17"
 
-"@vue/runtime-core@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.15.tgz#35c2ef61dadf07dfe9129dbea6fb8c1b88cc5bd6"
-  integrity sha512-jDkqSs1hsS9fRCgzah7VINafxWj7bYoDyweVuBqm6KPcHRfGkRZZxl2NltbbVaLH76Qvm4PPSnqGgEx7QtFSgg==
+"@vue/runtime-core@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.17.tgz#400a977398cb1689e225d884077d2dae7ce1e6b4"
+  integrity sha512-HOud3nuNAxBPPM66Mj4NRomdbeqIdR5ofSB+JgRHn/gS+7C13A/ww1XsKkjN6IzE8VgeJ3XHEBHrtDvBRYPfcg==
   dependencies:
-    "@vue/reactivity" "3.0.0-beta.15"
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/reactivity" "3.0.0-beta.17"
+    "@vue/shared" "3.0.0-beta.17"
 
-"@vue/runtime-dom@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.15.tgz#e3ce740c5e3766020719b174686bd65c75975c7e"
-  integrity sha512-161rUw1sWfbv51Ua8gKXaPc+seRJQcV+MLokTJtqYtNCajya0Mx6vdXJajBWqjDT8/Udx0sb7Wm/K/0DfGBUTw==
+"@vue/runtime-dom@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.17.tgz#a296ff81eebbaf7aa5d19cd76d595222f4636e48"
+  integrity sha512-FPV3fT8AFRQHuvjQ5/QxifU3LlMnyg1FzMHENedcu6lRrmUpnttexkOa51nZOrlFPI+Tz3mk297lohCp1QCMEA==
   dependencies:
-    "@vue/runtime-core" "3.0.0-beta.15"
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/runtime-core" "3.0.0-beta.17"
+    "@vue/shared" "3.0.0-beta.17"
     csstype "^2.6.8"
 
 "@vue/shared@3.0.0-beta.12":
@@ -1281,10 +1281,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.12.tgz#cb7a2bb047919d2c944bf822032b0a8aa869ba1d"
   integrity sha512-cA0DD3VFGYI76lbM90fAYXNJ9EmDNsm1tthO4FIY18DwziZKJWCfQBhEfHQd2skHcTE4OqH5eBxgsKEdn/LuGQ==
 
-"@vue/shared@3.0.0-beta.15":
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.15.tgz#77444ab234e229c3fdcc9f394678e167a55757af"
-  integrity sha512-wViILT5GgxMtnXVQ1xupj43wvnZ41g3NLWaBObs7l+eTxz5vq5yx72qH6HRpsfhR2Mg39jE0cfNLFEpC4lJIUQ==
+"@vue/shared@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.17.tgz#c9df723a3a3a39e47044ae8be60cce51c749ceb3"
+  integrity sha512-4vqmNjeY3prPbH2K9hKmXnzfU34ytT+Az971Ybc5WcjG6Vu+gEkXLHAQvQIoi9AYhCCuunvUi1r5IWFhGSHLww==
 
 abab@^2.0.0, abab@^2.0.3:
   version "2.0.3"
@@ -6007,14 +6007,14 @@ vue-jest@vuejs/vue-jest#next:
     extract-from-css "^0.4.4"
     ts-jest "^24.0.0"
 
-vue@^3.0.0-beta.15:
-  version "3.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.15.tgz#99f107534755d3a237b51fc1279c43af2fefde6e"
-  integrity sha512-KTmvfNpkvD6mao8vloqjUMjrHEivS1HZvHmYeHPRHqU2HRvNcrZuwXYvETt3dGOTu0Oj7zAWQXP+uZ34CW75sw==
+vue@^3.0.0-beta.16:
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.17.tgz#e361cfb18e3cb5576af27724fdb6e67e3fb45020"
+  integrity sha512-FrqKMCFbs3FHnYHf2uX7hkk0DKX+14SixX1vV5to8pwA97A55mrMmm+VqywRbPWfS2If9OByvhwuRL1+HRLY8g==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.15"
-    "@vue/runtime-dom" "3.0.0-beta.15"
-    "@vue/shared" "3.0.0-beta.15"
+    "@vue/compiler-dom" "3.0.0-beta.17"
+    "@vue/runtime-dom" "3.0.0-beta.17"
+    "@vue/shared" "3.0.0-beta.17"
 
 vuex@^4.0.0-beta.1:
   version "4.0.0-beta.1"


### PR DESCRIPTION
I was trying to update VTU 2.x from Vue beta.15 to beta.16 (beta.17 is the same), and we are having some regressions.

It looks like an SFC with just a template tag was passed to `transformVNodeArgs` as:
`{ render: [Function: render], name: 'component-without-name' }`
and now is passed as:
`{ render: [Function: render] }`
As we need the name for stubbing/shallow mount, we have test failures.