### PR TITLE
refactor: properly find/stub anonymous component

### DIFF
--- a/src/utils/matchName.ts
+++ b/src/utils/matchName.ts
@@ -1,6 +1,6 @@
 import { camelize, capitalize } from './vueShared'
 
-export function matchName(target, sourceName) {
+export function matchName(target: string, sourceName: string) {
   const camelized = camelize(target)
   const capitalized = capitalize(camelized)
 


### PR DESCRIPTION
Instead of always patching the missing name with the registration name, we now look into the parent registration only if the name is missing.
Some cases were trickier to handle (for example when we try to find a component that has been stubbed), but it looks like we are on par with what we had previously and we do not have the risk of multiple registration names erasing each other anymore.