### PR TITLE
feat: findComponent can find component inside a Suspense

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -106,9 +106,22 @@ function findAllVNodes(
   const nodes: VNode[] = [vnode]
   while (nodes.length) {
     const node = nodes.shift()!
+    // match direct children
     aggregateChildren(nodes, node.children)
     if (node.component) {
+      // match children of the wrapping component
       aggregateChildren(nodes, node.component.subTree.children)
+    }
+    if (node.suspense) {
+      // match children if component is Suspense
+      const { isResolved, fallbackTree, subTree } = node.suspense
+      if (isResolved) {
+        // if the suspense is resolved, we match its children
+        aggregateChildren(nodes, subTree.children)
+      } else {
+        // otherwise we match its fallback tree
+        aggregateChildren(nodes, fallbackTree.children)
+      }
     }
     if (matches(node, selector)) {
       matchingNodes.push(node)

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -2,7 +2,6 @@ import { defineComponent, h } from 'vue'
 
 import { mount } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
-import Hello from './components/Hello.vue'
 
 describe('find', () => {
   it('find using single root node', () => {


### PR DESCRIPTION
Slightly updates the find implementation to:
- check the suspense `subtree` if it is resolved
- check the suspense `fallbackTree` otherwise

A test has been added to check if we can find a component in both cases.