### PR TITLE
Feature/plugin options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -190,7 +190,7 @@ export default {}
 test('installs a plugin via `plugins`', () => {
   const installed = jest.fn()
   class Plugin {
-    static install() {
+    static install(app: App, options?: any) {
       installed()
     }
   }
@@ -199,7 +199,7 @@ test('installs a plugin via `plugins`', () => {
   }
   mount(Component, {
     global: {
-      plugins: [Plugin]
+      plugins: [{ plugin: Plugin, options: {} }]
     }
   })
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -187,23 +187,37 @@ export default {}
 ```
 
 ```js
-test('installs a plugin via `plugins`', () => {
+test('installs plugins via `plugins`', () => {
   const installed = jest.fn()
   class Plugin {
-    static install(app: App, options?: any) {
+    static install() {
       installed()
     }
   }
+
+  const installedWithOptions = jest.fn()
+  class PluginWithOptions {
+    static install(_app: App, ...args) {
+      installedWithOptions(...args)
+    }
+  }
+
   const Component = {
-    render() { return h('div') }
+    render() {
+      return h('div')
+    }
   }
   mount(Component, {
     global: {
-      plugins: [{ plugin: Plugin, options: {} }]
+      plugins: [Plugin, [PluginWithOptions, 'argument 1', 'another argument']]
     }
   })
 
   expect(installed).toHaveBeenCalled()
+  expect(installedWithOptions).toHaveBeenCalledWith(
+    'argument 1',
+    'another argument'
+  )
 })
 ```
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -312,7 +312,7 @@ export function mount(
 
   // use and plugins from mounting options
   if (global.plugins) {
-    for (const use of global.plugins) app.use(use)
+    for (const { plugin, options } of global.plugins) app.use(plugin, options)
   }
 
   // use any mixins from mounting options

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -312,7 +312,13 @@ export function mount(
 
   // use and plugins from mounting options
   if (global.plugins) {
-    for (const { plugin, options } of global.plugins) app.use(plugin, options)
+    for (const plugin of global.plugins) {
+      if (Array.isArray(plugin)) {
+        app.use(plugin[0], ...plugin.slice(1))
+        continue
+      }
+      app.use(plugin)
+    }
   }
 
   // use any mixins from mounting options

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type FindComponentSelector = RefSelector | NameSelector | string
 export type FindAllComponentsSelector = NameSelector | string
 
 export type GlobalMountOptions = {
-  plugins?: { plugin: Plugin; options?: any }[]
+  plugins?: (Plugin | [Plugin, ...any[]])[]
   config?: Omit<AppConfig, 'isNativeTag'> // isNativeTag is readonly, so we omit it
   mixins?: ComponentOptions[]
   mocks?: Record<string, any>

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type FindComponentSelector = RefSelector | NameSelector | string
 export type FindAllComponentsSelector = NameSelector | string
 
 export type GlobalMountOptions = {
-  plugins?: Plugin[]
+  plugins?: { plugin: Plugin; options?: any }[]
   config?: Omit<AppConfig, 'isNativeTag'> // isNativeTag is readonly, so we omit it
   mixins?: ComponentOptions[]
   mocks?: Record<string, any>

--- a/tests/features/vuex.spec.ts
+++ b/tests/features/vuex.spec.ts
@@ -30,7 +30,7 @@ describe('vuex', () => {
 
     const wrapper = mount(Foo, {
       global: {
-        plugins: [store]
+        plugins: [{ plugin: store }]
       }
     })
 

--- a/tests/features/vuex.spec.ts
+++ b/tests/features/vuex.spec.ts
@@ -30,7 +30,7 @@ describe('vuex', () => {
 
     const wrapper = mount(Foo, {
       global: {
-        plugins: [{ plugin: store }]
+        plugins: [store]
       }
     })
 

--- a/tests/mountingOptions/global.plugins.spec.ts
+++ b/tests/mountingOptions/global.plugins.spec.ts
@@ -19,7 +19,7 @@ describe('mounting options: plugins', () => {
     }
     mount(Component, {
       global: {
-        plugins: [{ plugin: Plugin }]
+        plugins: [Plugin]
       }
     })
 
@@ -30,8 +30,8 @@ describe('mounting options: plugins', () => {
     const installed = jest.fn()
 
     class Plugin {
-      static install(_app: App, options: { option1: boolean }) {
-        installed(options)
+      static install(_app: App, ...options) {
+        installed(...options)
       }
     }
 
@@ -41,12 +41,46 @@ describe('mounting options: plugins', () => {
       }
     }
     const options = { option1: true }
+    const testString = 'hello'
     mount(Component, {
       global: {
-        plugins: [{ plugin: Plugin, options }]
+        plugins: [[Plugin, options, testString]]
       }
     })
 
-    expect(installed).toHaveBeenCalledWith(options)
+    expect(installed).toHaveBeenCalledWith(options, testString)
   })
+})
+
+test('installs plugins with and without options', () => {
+  const installed = jest.fn()
+  class Plugin {
+    static install() {
+      installed()
+    }
+  }
+
+  const installedWithOptions = jest.fn()
+  class PluginWithOptions {
+    static install(_app: App, ...args) {
+      installedWithOptions(...args)
+    }
+  }
+
+  const Component = {
+    render() {
+      return h('div')
+    }
+  }
+  mount(Component, {
+    global: {
+      plugins: [Plugin, [PluginWithOptions, 'argument 1', 'another argument']]
+    }
+  })
+
+  expect(installed).toHaveBeenCalled()
+  expect(installedWithOptions).toHaveBeenCalledWith(
+    'argument 1',
+    'another argument'
+  )
 })

--- a/tests/mountingOptions/global.plugins.spec.ts
+++ b/tests/mountingOptions/global.plugins.spec.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { h, App } from 'vue'
 
 import { mount } from '../../src'
 
@@ -19,10 +19,34 @@ describe('mounting options: plugins', () => {
     }
     mount(Component, {
       global: {
-        plugins: [Plugin]
+        plugins: [{ plugin: Plugin }]
       }
     })
 
     expect(installed).toHaveBeenCalled()
+  })
+
+  it('installs a plugin with options `plugins`', () => {
+    const installed = jest.fn()
+
+    class Plugin {
+      static install(_app: App, options: { option1: boolean }) {
+        installed(options)
+      }
+    }
+
+    const Component = {
+      render() {
+        return h('div')
+      }
+    }
+    const options = { option1: true }
+    mount(Component, {
+      global: {
+        plugins: [{ plugin: Plugin, options }]
+      }
+    })
+
+    expect(installed).toHaveBeenCalledWith(options)
   })
 })


### PR DESCRIPTION
`app.use()` takes a plugin and optional arguments, but the test-utils don't support this. I adjusted the API to take either straight plugins (`plugins: [Plugin, AnotherPlugin]`) or nested arrays to provide those options to `app.use`:

```
plugins: [
  Plugin, 
  [PluginWithOptions, 'argument 1', 'another argument']
]
```

I first tried to use an object instead of a nested array, but that would likely lead to a breaking change because of unreliable type checks.