### PR TITLE
WIP: findComponent edge cases

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,4 +36,12 @@ function mergeGlobalProperties(
   }
 }
 
+export function isObject(value: any): value is object {
+  return typeof value === 'object'
+}
+
+export function isFunction(value: any): value is Function {
+  return typeof value === 'function'
+}
+
 export { mergeGlobalProperties }

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -20,7 +20,7 @@ export class VueWrapper<T extends ComponentPublicInstance> {
     setProps?: (props: Record<string, any>) => void
   ) {
     this.__app = app
-    this.rootVM = vm.$root!
+    this.rootVM = vm?.$root!
     this.componentVM = vm as T
     this.__setProps = setProps
     // plugins hook

--- a/tests/components/A.vue
+++ b/tests/components/A.vue
@@ -1,0 +1,12 @@
+<template>
+  <span><B /></span>
+</template>
+
+<script lang="ts">
+import B from './B.vue'
+
+export default {
+  name: 'A',
+  components: { B }
+}
+</script>

--- a/tests/components/B.vue
+++ b/tests/components/B.vue
@@ -1,0 +1,13 @@
+<template>
+  <span><C><D /></C></span>
+</template>
+
+<script lang="ts">
+import C from './C.vue'
+import D from './D.vue'
+
+export default {
+  name: 'B',
+  components: { C, D }
+}
+</script>

--- a/tests/components/C.vue
+++ b/tests/components/C.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>C <slot /></div>
+</template>
+
+<script lang="ts">
+
+export default {
+  name: 'C',
+}
+</script>

--- a/tests/components/ComponentA.vue
+++ b/tests/components/ComponentA.vue
@@ -1,0 +1,10 @@
+<template>
+  <div><slot></slot></div>
+</template>
+
+<script lang="ts">
+
+export default {
+  name: 'ComponentA',
+}
+</script>

--- a/tests/components/ComponentB.vue
+++ b/tests/components/ComponentB.vue
@@ -1,0 +1,10 @@
+<template>
+  <div><slot></slot></div>
+</template>
+
+<script lang="ts">
+
+export default {
+  name: 'ComponentB',
+}
+</script>

--- a/tests/components/D.vue
+++ b/tests/components/D.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>D</div>
+</template>
+
+<script lang="ts">
+
+export default {
+  name: 'D',
+}
+</script>

--- a/tests/components/Issue.vue
+++ b/tests/components/Issue.vue
@@ -1,0 +1,25 @@
+<template>
+  <ComponentA>
+    <ComponentB>
+      <div class="content" id="1">1</div>
+    </ComponentB>
+    <ComponentB>
+      <div class="content" id="2">2</div>
+    </ComponentB>
+    <ComponentB>
+      <div class="content" id="3">3</div>
+    </ComponentB>
+  </ComponentA>
+</template>
+
+<script lang="ts">
+import ComponentA from './ComponentA.vue'
+import ComponentB from './ComponentB.vue'
+
+export default {
+  components: {
+    ComponentA,
+    ComponentB
+  }
+}
+</script>

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -2,6 +2,11 @@ import { defineComponent, nextTick, h } from 'vue'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 import ComponentWithoutName from './components/ComponentWithoutName.vue'
+import ComponentBSFC from './components/ComponentB.vue'
+import Issue from './components/Issue.vue'
+import A from './components/A.vue'
+import C from './components/C.vue'
+import D from './components/D.vue'
 
 const compC = defineComponent({
   name: 'ComponentC',
@@ -273,6 +278,15 @@ describe('findComponent', () => {
     expect(compB[0].vm.$el.querySelector('.content').textContent).toBe('1')
   })
 
+  it('finds nested components and obtains expected html and innerText using SFCs', () => {
+    const wrapper = mount(Issue)
+
+    const compB = wrapper.findAllComponents(ComponentBSFC)
+    expect(compB[0].find('.content').text()).toBe('1')
+    expect(compB[0].vm.$el.querySelector('.content').innerHTML).toBe('1')
+    expect(compB[0].vm.$el.querySelector('.content').textContent).toBe('1')
+  })
+
   it('finds component in deeply nested render function and slots', () => {
     const ComponentA = {
       name: 'ComponentA',
@@ -318,5 +332,19 @@ describe('findComponent', () => {
     const wrapper = mount(App)
 
     wrapper.getComponent(Functional)
+  })
+
+  it('nested SFCs', () => {
+    const App = {
+      name: 'Main',
+      render() {
+        return h(A)
+      }
+    }
+
+    const wrapper = mount(App)
+
+    wrapper.getComponent(C)
+    wrapper.getComponent(D)
   })
 })


### PR DESCRIPTION
Hi all! This is a bug write-up and I would like some feedback from everyone.

TL;DR is `findComponent` seems very difficult support. I could be wrong but either way here is my findings and some options.

The current implementation very buggy (to the point it isn't really useful). See this issue for some context: https://github.com/vuejs/vue-test-utils-next/issues/180

I rewrote the `findVNodes` function to covert some of the edge cases. How it works: basically all components have the concept of a `subTree`, which stores the components VDOM state. We recurse down each level via `subTree` or `children`. It works for some cases, but not for others. Here are the cases I cannot find a solution for:

- functional components. No instance, so you cannot `findComponent` them, or at least when you do find them you cannot get the instance, which means no `VueWrapper`. I found a fix for this in this PR. But, since there is no instance, you cannot access `.vm` and all the stuff you would expect (like props etc). We could return a `DOMWrapper`, but this feels wrong. Users will expect `findComponent` to find a component. The whole point of splitting `find` and  findComponent` was to emphasis the difference in the two.
- slots and inline templates. These is the real blocker here! You can see how I access slot content in this this PR.  Basically, when using slots and components with inline `templates`, the `subTree` is different and there seems not way to get the instance via recursing down.

Some (not all) these issues seem to go away when we use SFC (via `vue-jest`). I guess we need to dig deeper into how Vue compiles things. The original issue in #180 is fixed by using SFCs. 🤷‍♂️ Interesting. Other are not.

Here are my proposed solutions:

- add an additional wrapper. This would something like `FunctionalWrapper` that returns the non-instance with some limited methods we can support (eg, `html()` and `attributes` for static HTML attributes). Not ideal.
- dive deeper and use `@vue/compiler-sfc` to compile all non-SFC components to SFCs. This seems it might work. This is how `vue-jest` works and pre-compiled SFCs seem not to have the same caveats. This would be a long term goal, at least if I need to write the code (I also need to focus on other bugs, vue-jest, VTU v1...).
- (**my favorite solution**) *until* we figure out how to solve the problems for non SFC components, put a warning that says "findComponent currently only supports SFCs. Non SFC support is experimental. We are working on supporting all manner of components". The reason I like this is so I don't have to keep telling people about work-arounds and triaging issues about the same thing. I'd much prefer a library with limitations that works really well, than one without limitations that doesn't. It feels more polished.

Tagging all the people who have expressed interested in contributing to and improving VTU in the last few weeks. Please give me your input!

Here is a screenshot explaining the problem:

![image](https://user-images.githubusercontent.com/19196536/90977101-3cffd900-e586-11ea-8add-c15b320d9a9c.png)

![image](https://user-images.githubusercontent.com/19196536/90977170-abdd3200-e586-11ea-8cf4-c2a51c32d112.png)


@afontcu @dobromir-hristov @JeremyWuuuuu @JessicaSachs @cexbrayat @Jokcy @AngeloGulina @AtofStryker
