### PR TITLE
fix: make get() return type adhering to its return type

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -125,12 +125,12 @@ export class VueWrapper<T extends ComponentPublicInstance> {
 
   get<K extends keyof HTMLElementTagNameMap>(
     selector: K
-  ): DOMWrapper<HTMLElementTagNameMap[K]>
+  ): Omit<DOMWrapper<HTMLElementTagNameMap[K]>, 'exists'>
   get<K extends keyof SVGElementTagNameMap>(
     selector: K
-  ): DOMWrapper<SVGElementTagNameMap[K]>
-  get<T extends Element>(selector: string): DOMWrapper<T>
-  get(selector: string): DOMWrapper<Element> {
+  ): Omit<DOMWrapper<SVGElementTagNameMap[K]>, 'exists'>
+  get<T extends Element>(selector: string): Omit<DOMWrapper<T>, 'exists'>
+  get(selector: string): Omit<DOMWrapper<Element>, 'exists'> {
     const result = this.find(selector)
     if (result instanceof DOMWrapper) {
       return result
@@ -169,13 +169,13 @@ export class VueWrapper<T extends ComponentPublicInstance> {
 
   getComponent<T extends ComponentPublicInstance>(
     selector: new () => T
-  ): VueWrapper<T>
+  ): Omit<VueWrapper<T>, 'exists'>
   getComponent<T extends ComponentPublicInstance>(
     selector: FindComponentSelector
-  ): VueWrapper<T>
+  ): Omit<VueWrapper<T>, 'exists'>
   getComponent<T extends ComponentPublicInstance>(
     selector: any
-  ): VueWrapper<T> {
+  ): Omit<VueWrapper<T>, 'exists'> {
     const result = this.findComponent(selector)
 
     if (result instanceof VueWrapper) {


### PR DESCRIPTION
Refers to [this](https://github.com/vuejs/vue-test-utils-next/issues/176)

This MR suggests to improve the guideline that `get()` should (and cannot) be used in combination with `exists()` by removing it from its return type.

The following changes only affect TS users as they will now see an error when using `exists()` on the returned `get()` result (it's assumed that when `get()` cannot find an element, it will just throw). They will need to update the code to use `find()` which is [the official recommendation](https://github.com/vuejs/vue-test-utils-next-docs/pull/48).