### PR TITLE
wip: data typing issue

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -42,7 +42,7 @@ type SlotDictionary = {
 
 interface MountingOptions<Props, Data = {}> {
   data?: () => {} extends Data
-    ? never
+    ? {}
     : Data extends object
     ? Partial<Data>
     : never

--- a/src/vueShims.d.ts
+++ b/src/vueShims.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
   // TODO: Figure out the typing for this
-  import Vue from 'vue'
-  export default any
+  const component: any
+  export default component
 }

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -1,6 +1,8 @@
 import { expectError, expectType } from 'tsd'
 import { defineComponent } from 'vue'
 import { mount } from '../src'
+// @ts-ignore
+import Hello from '../tests/components/Hello.vue'
 
 const AppWithDefine = defineComponent({
   props: {
@@ -18,17 +20,6 @@ expectType<string>(
   mount(AppWithDefine, {
     props: { a: 'Hello', b: 2 }
   }).vm.a
-)
-
-// no data provided
-expectError(
-  mount(AppWithDefine, {
-    data() {
-      return {
-        myVal: 1
-      }
-    }
-  })
 )
 
 // can not receive extra props
@@ -150,6 +141,15 @@ mount(AppWithProps, {
   global: {
     config: {
       isCustomElement: (tag: string) => true
+    }
+  }
+})
+
+// SFC with data option
+mount(Hello, {
+  data() {
+    return {
+      foo: 'bar'
     }
   }
 })


### PR DESCRIPTION
This lets you use `data` with SFC imports as described in #194, but breaks the type safety for non SFCs. This seems unavoidable - I don't see how we can have the best of both words here, really.

I don't see a good solution for this in the short term, unless someone has figured a good way to extract type info from `.vue` files (not yet, or at least not stable yet).

Any ideas? Using `vue` files is much more common than using components defined with render functions, but I really value strong typing as well. I wonder if there is some way to not have as string type-checking for `.vue` files (using a shim). Eg: disable mounting option checks for shimmed vue files. I will do some research.

@cexbrayat @pikax would love some input. 