### PR TITLE
feat(mount): add support for propsData

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -47,6 +47,8 @@ interface MountingOptions<Props, Data = {}> {
     ? Partial<Data>
     : never
   props?: Props
+  /** @deprecated */
+  propsData?: Props
   attrs?: Record<string, unknown>
   slots?: SlotDictionary & {
     default?: Slot
@@ -258,6 +260,7 @@ export function mount(
   // Vue's reactivity system will cause a rerender.
   const props = reactive({
     ...options?.attrs,
+    ...options?.propsData,
     ...options?.props,
     ref: MOUNT_COMPONENT_REF
   })

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -20,6 +20,13 @@ expectType<string>(
   }).vm.a
 )
 
+// accept propsData - vm is properly typed
+expectType<string>(
+  mount(AppWithDefine, {
+    propsData: { a: 'Hello', b: 2 }
+  }).vm.a
+)
+
 // no data provided
 expectError(
   mount(AppWithDefine, {

--- a/tests/mountingOptions/props.spec.ts
+++ b/tests/mountingOptions/props.spec.ts
@@ -26,6 +26,27 @@ describe('mountingOptions.props', () => {
     expect(wrapper.text()).toBe('Message is Hello')
   })
 
+  test("passes props with 'propsData'", () => {
+    const wrapper = mount(Component, {
+      propsData: {
+        message: 'Hello'
+      }
+    })
+    expect(wrapper.text()).toBe('Message is Hello')
+  })
+
+  test("uses props from 'props' attribute, when 'propsData' also contains same attribute keys", () => {
+    const wrapper = mount(Component, {
+      propsData: {
+        message: 'Hello from propsData'
+      },
+      props: {
+        message: 'Hello from props'
+      }
+    })
+    expect(wrapper.text()).toBe('Message is Hello from props')
+  })
+
   test('assigns extra properties as attributes on components', () => {
     const wrapper = mount(Component, {
       props: {


### PR DESCRIPTION
 - Adds support for mounting with `propsData` option,
   for backwards compatibility.

See https://github.com/vuejs/vue-test-utils-next/issues/204

Added two tests to be clear what happens when both `props` and `propsData` are provided. Happy to change implementation to a different behaviour if that would be preferred. 

(No warning/error is given to the user if both `props` and `propsData` are used in the mounting options.)