### PR TITLE
Add isVisible and stub transition/transition-group by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
+import { ComponentPublicInstance } from 'vue'
 import { GlobalMountOptions } from './types'
 import { VueWrapper } from './vueWrapper'
-import { ComponentPublicInstance } from 'vue'
 
 interface GlobalConfigOptions {
   global: GlobalMountOptions
@@ -19,7 +19,7 @@ interface Plugin {
 }
 
 class Pluggable {
-  installedPlugins = [] as Array<Plugin>
+  installedPlugins: Plugin[] = []
 
   install(
     handler: (
@@ -55,7 +55,12 @@ class Pluggable {
 }
 
 export const config: GlobalConfigOptions = {
-  global: {},
+  global: {
+    stubs: {
+      transition: true,
+      'transition-group': true
+    }
+  },
   plugins: {
     VueWrapper: new Pluggable(),
     DOMWrapper: new Pluggable()

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -2,6 +2,7 @@ import { nextTick } from 'vue'
 
 import { createWrapperError } from './errorWrapper'
 import { TriggerOptions, createDOMEvent } from './createDomEvent'
+import { isElementVisible } from './utils/isElementVisible'
 
 export class DOMWrapper<ElementType extends Element> {
   element: ElementType
@@ -34,6 +35,10 @@ export class DOMWrapper<ElementType extends Element> {
 
   exists() {
     return true
+  }
+
+  isVisible() {
+    return isElementVisible(this.element)
   }
 
   text() {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -350,12 +350,9 @@ export function mount(
   app.mixin(attachEmitListener())
 
   // stubs
-  if (global.stubs || options?.shallow) {
-    stubComponents(global.stubs, options?.shallow)
-  } else {
-    // still apply default stub of Transition and Transition Group
-    stubComponents()
-  }
+  // even if we are using `mount`, we will still
+  // stub out Transition and Transition Group by default.
+  stubComponents(global.stubs, options?.shallow)
 
   // mount the app!
   const vm = app.mount(el)

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -353,7 +353,8 @@ export function mount(
   if (global.stubs || options?.shallow) {
     stubComponents(global.stubs, options?.shallow)
   } else {
-    transformVNodeArgs()
+    // still apply default stub of Transition and Transition Group
+    stubComponents()
   }
 
   // mount the app!

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -36,12 +36,15 @@ const createStub = ({ name, props }: StubOptions): ComponentOptions => {
   return defineComponent({ name: name || anonName, render, props })
 }
 
-const createTransitionStub = ({ props }: StubOptions): ComponentOptions => {
+const createTransitionStub = ({
+  name,
+  props
+}: StubOptions): ComponentOptions => {
   const render = (ctx: ComponentPublicInstance) => {
-    return h('transition-stub', {}, ctx.$slots)
+    return h(name, {}, ctx.$slots)
   }
 
-  return defineComponent({ name: 'transition-stub', render, props })
+  return defineComponent({ name, render, props })
 }
 
 const resolveComponentStubByName = (
@@ -93,11 +96,22 @@ export function stubComponents(
     // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
     // Depending what it is, we do different things.
     if (type === Transition && stubs['transition']) {
-      return [createTransitionStub({ props: undefined }), undefined, children]
+      return [
+        createTransitionStub({ name: 'transition-stub', props: undefined }),
+        undefined,
+        children
+      ]
     }
 
     if (type === TransitionGroup && stubs['transition-group']) {
-      return [createTransitionStub({ props: undefined }), undefined, children]
+      return [
+        createTransitionStub({
+          name: 'transition-group-stub',
+          props: undefined
+        }),
+        undefined,
+        children
+      ]
     }
 
     if (

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -91,10 +91,8 @@ export function stubComponents(
   transformVNodeArgs((args, instance: ComponentInternalInstance | null) => {
     const [nodeType, props, children, patchFlag, dynamicProps] = args
     const type = nodeType as VNodeTypes
-    // args[0] can either be:
-    // 1. a HTML tag (div, span...)
-    // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
-    // Depending what it is, we do different things.
+
+    // stub transition by default via config.global.stubs
     if (type === Transition && stubs['transition']) {
       return [
         createTransitionStub({ name: 'transition-stub', props: undefined }),
@@ -103,6 +101,7 @@ export function stubComponents(
       ]
     }
 
+    // stub transition-group by default via config.global.stubs
     if (type === TransitionGroup && stubs['transition-group']) {
       return [
         createTransitionStub({
@@ -114,6 +113,10 @@ export function stubComponents(
       ]
     }
 
+    // args[0] can either be:
+    // 1. a HTML tag (div, span...)
+    // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
+    // Depending what it is, we do different things.
     if (
       isHTMLElement(type) ||
       isCommentOrFragment(type) ||

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,5 +1,7 @@
 import {
   transformVNodeArgs,
+  Transition,
+  TransitionGroup,
   h,
   ComponentPublicInstance,
   Slots,
@@ -32,6 +34,14 @@ const createStub = ({ name, props }: StubOptions): ComponentOptions => {
   }
 
   return defineComponent({ name: name || anonName, render, props })
+}
+
+const createTransitionStub = ({ props }: StubOptions): ComponentOptions => {
+  const render = (ctx: ComponentPublicInstance) => {
+    return h('transition-stub', {}, ctx.$slots)
+  }
+
+  return defineComponent({ name: 'transition-stub', render, props })
 }
 
 const resolveComponentStubByName = (
@@ -82,6 +92,10 @@ export function stubComponents(
     // 1. a HTML tag (div, span...)
     // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
     // Depending what it is, we do different things.
+    if (type === Transition || type === TransitionGroup) {
+      return [createTransitionStub({ props: undefined }), undefined, children]
+    }
+
     if (
       isHTMLElement(type) ||
       isCommentOrFragment(type) ||

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -92,7 +92,11 @@ export function stubComponents(
     // 1. a HTML tag (div, span...)
     // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
     // Depending what it is, we do different things.
-    if (type === Transition || type === TransitionGroup) {
+    if (type === Transition && stubs['transition']) {
+      return [createTransitionStub({ props: undefined }), undefined, children]
+    }
+
+    if (type === TransitionGroup && stubs['transition-group']) {
       return [createTransitionStub({ props: undefined }), undefined, children]
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type GlobalMountOptions = {
   components?: Record<string, Component | object>
   directives?: Record<string, Directive>
   stubs?: Record<any, any>
+  renderStubDefaultSlot?: boolean
 }
 
 export interface VueWrapperMeta {

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -1,0 +1,33 @@
+/*!
+ * isElementVisible
+ * Adapted from https://github.com/testing-library/jest-dom
+ * Licensed under the MIT License.
+ */
+
+type StylableElement = HTMLElement | SVGElement
+
+function isStyleVisible<T extends StylableElement>(element: T) {
+  const { display, visibility, opacity } = element.style
+  return (
+    display !== 'none' &&
+    visibility !== 'hidden' &&
+    visibility !== 'collapse' &&
+    opacity !== '0'
+  )
+}
+
+function isAttributeVisible<T extends StylableElement>(element: T) {
+  return (
+    !element.hasAttribute('hidden') &&
+    (element.nodeName === 'DETAILS' ? element.hasAttribute('open') : true)
+  )
+}
+
+export function isElementVisible<T extends StylableElement>(element: T) {
+  return (
+    element.nodeName !== '#comment' &&
+    isStyleVisible(element) &&
+    isAttributeVisible(element) &&
+    (!element.parentElement || isElementVisible(element.parentElement))
+  )
+}

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -4,10 +4,13 @@
  * Licensed under the MIT License.
  */
 
-type StylableElement = HTMLElement | SVGElement
+function isStyleVisible<T extends Element>(element: T) {
+  if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
+    return false
+  }
 
-function isStyleVisible<T extends StylableElement>(element: T) {
   const { display, visibility, opacity } = element.style
+
   return (
     display !== 'none' &&
     visibility !== 'hidden' &&
@@ -16,14 +19,14 @@ function isStyleVisible<T extends StylableElement>(element: T) {
   )
 }
 
-function isAttributeVisible<T extends StylableElement>(element: T) {
+function isAttributeVisible<T extends Element>(element: T) {
   return (
     !element.hasAttribute('hidden') &&
     (element.nodeName === 'DETAILS' ? element.hasAttribute('open') : true)
   )
 }
 
-export function isElementVisible<T extends StylableElement>(element: T) {
+export function isElementVisible<T extends Element>(element: T) {
   return (
     element.nodeName !== '#comment' &&
     isStyleVisible(element) &&

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -45,4 +45,65 @@ describe('isVisible', () => {
     await wrapper.find('button').trigger('click')
     expect(wrapper.find('span').isVisible()).toBe(false)
   })
+
+  it('handles transitions', async () => {
+    const Comp = {
+      template: `
+        <button @click="show = false" />
+        <transition name="fade">
+          <span class="item" v-show="show">
+            Content
+          </span>
+        </transition>
+      `,
+      data() {
+        return {
+          show: true
+        }
+      }
+    }
+    const wrapper = mount(Comp, {})
+
+    expect(wrapper.find('span').isVisible()).toBe(true)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('span').isVisible()).toBe(false)
+  })
+
+  it('handles transition-group', async () => {
+    const Comp = {
+      template: `
+        <div id="list-demo">
+          <button @click="add" id="add">Add</button>
+          <button @click="remove" id="remove">Remove</button>
+          <transition-group name="list" tag="p">
+            <span v-for="item in items" :key="item" class="list-item">
+              Item: {{ item }}
+            </span>
+          </transition-group>
+        </div>
+      `,
+      methods: {
+        add() {
+          this.items.push(2)
+        },
+        remove() {
+          this.items.splice(1) // back to [1]
+        }
+      },
+      data() {
+        return {
+          items: [1]
+        }
+      }
+    }
+    const wrapper = mount(Comp)
+
+    expect(wrapper.html()).toContain('Item: 1')
+    await wrapper.find('#add').trigger('click')
+    expect(wrapper.html()).toContain('Item: 1')
+    expect(wrapper.html()).toContain('Item: 2')
+    await wrapper.find('#remove').trigger('click')
+    expect(wrapper.html()).toContain('Item: 1')
+    expect(wrapper.html()).not.toContain('Item: 2')
+  })
 })

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -1,0 +1,48 @@
+import { mount } from '../src'
+
+describe('isVisible', () => {
+  const Comp = {
+    template: `<div><span v-show="show" /></div>`,
+    props: {
+      show: {
+        type: Boolean
+      }
+    }
+  }
+
+  it('returns false when element hidden via v-show', () => {
+    const wrapper = mount(Comp, {
+      props: {
+        show: false
+      }
+    })
+
+    expect(wrapper.find('span').isVisible()).toBe(false)
+  })
+
+  it('returns true when element is visible via v-show', () => {
+    const wrapper = mount(Comp, {
+      props: {
+        show: true
+      }
+    })
+
+    expect(wrapper.find('span').isVisible()).toBe(true)
+  })
+
+  it('element becomes hidden reactively', async () => {
+    const Comp = {
+      template: `<button @click="show = false" /><span v-show="show" />`,
+      data() {
+        return {
+          show: true
+        }
+      }
+    }
+    const wrapper = mount(Comp)
+
+    expect(wrapper.find('span').isVisible()).toBe(true)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('span').isVisible()).toBe(false)
+  })
+})

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -30,6 +30,15 @@ describe('isVisible', () => {
     expect(wrapper.find('span').isVisible()).toBe(true)
   })
 
+  it('returns false when element parent is invisible via v-show', () => {
+    const Comp = {
+      template: `<div v-show="false"><span /></div>`
+    }
+    const wrapper = mount(Comp)
+
+    expect(wrapper.find('span').isVisible()).toBe(false)
+  })
+
   it('element becomes hidden reactively', async () => {
     const Comp = {
       template: `<button @click="show = false" /><span v-show="show" />`,

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -6,12 +6,13 @@ import ComponentWithoutName from '../components/ComponentWithoutName.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
 
 describe('mounting options: stubs', () => {
+  let configStubsSave = config.global.stubs
   beforeEach(() => {
-    config.global.stubs = {}
+    config.global.stubs = configStubsSave
   })
 
   afterEach(() => {
-    config.global.stubs = {}
+    config.global.stubs = configStubsSave
   })
 
   it('handles Array syntax', () => {
@@ -306,6 +307,59 @@ describe('mounting options: stubs', () => {
     })
 
     expect(wrapper.html()).toBe('<foo-bar-stub></foo-bar-stub>')
+  })
+
+  it('stubs transition by default', () => {
+    const Comp = {
+      template: `<transition><div id="content" /></transition>`
+    }
+    const wrapper = mount(Comp)
+
+    expect(wrapper.html()).toBe(
+      '<transition-stub><div id="content"></div></transition-stub>'
+    )
+  })
+
+  it('opts out of stubbing transition by default', () => {
+    const Comp = {
+      template: `<transition><div id="content" /></transition>`
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          transition: false
+        }
+      }
+    })
+
+    // Vue removes <transition> at run-time and does it's magic, so <transition> should not
+    // appear in the html when it isn't stubbed.
+    expect(wrapper.html()).toBe('<div id="content"></div>')
+  })
+
+  it('opts out of stubbing transition-group by default', () => {
+    const Comp = {
+      template: `<transition-group><div key="content" id="content" /></transition-group>`
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          'transition-group': false
+        }
+      }
+    })
+
+    // Vue removes <transition-group> at run-time and does it's magic, so <transition-group> should not
+    // appear in the html when it isn't stubbed.
+    expect(wrapper.html()).toBe('<div id="content"></div>')
+  })
+
+  it('stubs transition-group by default', () => {
+    const Comp = {
+      template: `<transition-group><div key="a" id="content" /></transition-group>`
+    }
+    const wrapper = mount(Comp)
+    expect(wrapper.find('#content').exists()).toBe(true)
   })
 
   describe('stub slots', () => {


### PR DESCRIPTION
resolves #210 

- Add `isVisible` back. We decided to un-deprecate it in V1, porting it to V2.
- We stub transition and transition group by default in V1. We will do the same here for consistency.
- This solves the problem in #210 (see there for more context)
- Stubbing transitions avoids the problem where transitions take time (eg 0.25s) and your assertion runs before your transition has finished. In unit tests you don't really care about things like CSS transitions; you just care if things are visible or not via `v-show`.
- You can opt out on a test-by-test basis by passing `transition: false` and `transition-group: false` to `global.stubs`.
- you can opt out globally by doing `config.global.stubs = { transition: false }`. This is useful for libraries like [cypress-vue](https://github.com/bahmutov/cypress-vue-unit-test) who do not stub things, since they are not constrained by things like `nextTick` like when testing in jsdom with jest.
