### PR TITLE
fix: allow finding root component

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -13,7 +13,10 @@ import { matchName } from './matchName'
  * @param selector
  * @return {boolean | ((value: any) => boolean)}
  */
-function matches(node: VNode, selector: FindAllComponentsSelector): boolean {
+export function matches(
+  node: VNode,
+  selector: FindAllComponentsSelector
+): boolean {
   // do not return none Vue components
   if (!node.component) return false
 
@@ -54,7 +57,9 @@ function matches(node: VNode, selector: FindAllComponentsSelector): boolean {
         }
       }
       // we may have one or both missing names
-      return matchName(selectorName, componentName)
+      if (selectorName && componentName) {
+        return matchName(selectorName, componentName)
+      }
     }
   }
 

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -10,7 +10,7 @@ import {
 } from './types'
 import { createWrapperError } from './errorWrapper'
 import { TriggerOptions } from './createDomEvent'
-import { find } from './utils/find'
+import { find, matches } from './utils/find'
 import { isFunctionalComponent } from './utils'
 
 export class VueWrapper<T extends ComponentPublicInstance> {
@@ -161,6 +161,16 @@ export class VueWrapper<T extends ComponentPublicInstance> {
     if (result.length) {
       return createWrapper(null, result[0], {
         isFunctionalComponent: isFunctionalComponent(result)
+      })
+    }
+
+    // https://github.com/vuejs/vue-test-utils-next/issues/211
+    // VTU v1 supported finding the component mounted itself.
+    // eg: mount(Comp).findComponent(Comp)
+    // this is the same as doing `wrapper.vm`, but we keep this behavior for back compat.
+    if (matches(this.vm.$.vnode, selector)) {
+      return createWrapper(null, this.vm.$.vnode.component.proxy, {
+        isFunctionalComponent: false
       })
     }
 

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -4,7 +4,7 @@ import Hello from './components/Hello.vue'
 import ComponentWithoutName from './components/ComponentWithoutName.vue'
 
 const compC = defineComponent({
-  name: 'ComponentC',
+  // name: 'ComponentC',
   template: '<div class="C">C</div>'
 })
 
@@ -28,6 +28,7 @@ const compB = defineComponent({
 })
 
 const compA = defineComponent({
+  name: 'A',
   template: `
     <div class="A">
       <comp-b />
@@ -80,6 +81,11 @@ describe('findComponent', () => {
     expect(wrapper.findComponent({ name: 'Hello' }).text()).toBe('Hello world')
     expect(wrapper.findComponent({ name: 'ComponentB' }).exists()).toBeTruthy()
     expect(wrapper.findComponent({ name: 'component-c' }).exists()).toBeTruthy()
+  })
+
+  it('finds root component', () => {
+    const wrapper = mount(compA)
+    expect(wrapper.findComponent(compA).exists()).toBe(true)
   })
 
   it('finds component without a name by using its object definition', () => {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -4,7 +4,7 @@ import Hello from './components/Hello.vue'
 import ComponentWithoutName from './components/ComponentWithoutName.vue'
 
 const compC = defineComponent({
-  // name: 'ComponentC',
+  name: 'ComponentC',
   template: '<div class="C">C</div>'
 })
 
@@ -83,9 +83,21 @@ describe('findComponent', () => {
     expect(wrapper.findComponent({ name: 'component-c' }).exists()).toBeTruthy()
   })
 
-  it('finds root component', () => {
-    const wrapper = mount(compA)
-    expect(wrapper.findComponent(compA).exists()).toBe(true)
+  it('finds root component', async () => {
+    const Comp = defineComponent({
+      name: 'C',
+      template: `
+        <input v-model="msg" />
+        {{ msg }}
+      `,
+      data() {
+        return { msg: 'foo' }
+      }
+    })
+    const wrapper = mount(Comp)
+    expect(wrapper.findComponent(Comp).exists()).toBe(true)
+    await wrapper.find('input').setValue('bar')
+    expect(wrapper.html()).toContain('bar')
   })
 
   it('finds component without a name by using its object definition', () => {


### PR DESCRIPTION
See: https://github.com/vuejs/vue-test-utils-next/issues/211 (resolves #211)

This seems like a kind of strange thing to have, but I would like to keep back-compat as much as possible. Apparently this worked in V1 (no idea what the use case is).

I could not get this to work without giving a `name` to the component; so it's not perfect in terms of back-compat.