### PR TITLE
[fix] apply DOMWrapper plugins in constructor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,30 +1,27 @@
 import { ComponentPublicInstance } from 'vue'
 import { GlobalMountOptions } from './types'
 import { VueWrapper } from './vueWrapper'
+import { DOMWrapper } from './domWrapper'
 
 interface GlobalConfigOptions {
   global: GlobalMountOptions
   plugins: {
-    VueWrapper: Pluggable
-    DOMWrapper: Pluggable
+    VueWrapper: Pluggable<VueWrapper<ComponentPublicInstance>>
+    DOMWrapper: Pluggable<DOMWrapper<Element>>
   }
   renderStubDefaultSlot: boolean
 }
 
-interface Plugin {
-  handler: (
-    instance: VueWrapper<ComponentPublicInstance>
-  ) => Record<string, any>
+interface Plugin<Instance> {
+  handler: (instance: Instance) => Record<string, any>
   options: Record<string, any>
 }
 
-class Pluggable {
-  installedPlugins: Plugin[] = []
+class Pluggable<Instance = DOMWrapper<Element>> {
+  installedPlugins: Plugin<Instance>[] = []
 
   install(
-    handler: (
-      instance: VueWrapper<ComponentPublicInstance>
-    ) => Record<string, any>,
+    handler: (instance: Instance) => Record<string, any>,
     options: Record<string, any> = {}
   ) {
     if (typeof handler !== 'function') {
@@ -34,8 +31,8 @@ class Pluggable {
     this.installedPlugins.push({ handler, options })
   }
 
-  extend(instance: VueWrapper<ComponentPublicInstance>) {
-    const invokeSetup = (plugin: Plugin) => plugin.handler(instance) // invoke the setup method passed to install
+  extend(instance: Instance) {
+    const invokeSetup = (plugin: Plugin<Instance>) => plugin.handler(instance) // invoke the setup method passed to install
     const bindProperty = ([property, value]: [string, any]) => {
       ;(instance as any)[property] =
         typeof value === 'function' ? value.bind(instance) : value

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -2,12 +2,15 @@ import { nextTick } from 'vue'
 
 import { createWrapperError } from './errorWrapper'
 import { TriggerOptions, createDOMEvent } from './createDomEvent'
+import { config } from './config'
 
 export class DOMWrapper<ElementType extends Element> {
   element: ElementType
 
   constructor(element: ElementType) {
     this.element = element
+    // plugins hook
+    config.plugins.DOMWrapper.extend(this)
   }
 
   classes(): string[]


### PR DESCRIPTION
Currently `config.plugins.DOMWrapper.install` does not work