### PR TITLE
fix: set default event.cancelable from dom-event-types

### DIFF
--- a/src/createDomEvent.ts
+++ b/src/createDomEvent.ts
@@ -112,7 +112,7 @@ function getEventProperties(eventParams: EventParams) {
     ...systemModifiersMeta, // shiftKey, metaKey etc
     ...options, // What the user passed in as the second argument to #trigger
     bubbles: meta.bubbles,
-    meta: meta.cancelable,
+    cancelable: meta.cancelable,
     // Any derived options should go here
     keyCode,
     code: keyCode,


### PR DESCRIPTION
This resolves #218 which may be caused by a simple typo in the codebase.

It seems like a core intent of `getEventProperties` is to source default properties of different types of DOM events from the 'dom-event-types' dep and provide them as properties for new events. However, it looks like the `cancelable` property is not being added to the returned object.

This change resolves the bug I'm seeing in #218 by allowing `click` events to have `preventDefault` work correctly.

I'd be happy to add a test case to test against regression here, but it doesn't seem like a logic bug or something that's likely to be reverted if my above assumptions seem reasonable.