### PR TITLE
fix: update vue shims to use DefineComponent

### DIFF
--- a/src/vueShims.d.ts
+++ b/src/vueShims.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-  // TODO: Figure out the typing for this
-  import Vue from 'vue'
-  export default any
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent
+  export default component
 }


### PR DESCRIPTION
This is a repro to showcase the issue introduced by https://github.com/vuejs/vue-next/commit/6aa2256913bfd097500aba83b78482b87107c101

As soon as we start using the proper shim for SFC (the one used by the CLI) then we see the issue.