### PR TITLE
refactor: do not pollute markup with useless id

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,2 @@
-export const MOUNT_ELEMENT_ID = 'app'
 export const MOUNT_COMPONENT_REF = 'VTU_COMPONENT'
 export const MOUNT_PARENT_NAME = 'VTU_ROOT'

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -27,11 +27,7 @@ import { processSlot } from './utils/compileSlots'
 import { createWrapper, VueWrapper } from './vueWrapper'
 import { attachEmitListener } from './emitMixin'
 import { createDataMixin } from './dataMixin'
-import {
-  MOUNT_COMPONENT_REF,
-  MOUNT_ELEMENT_ID,
-  MOUNT_PARENT_NAME
-} from './constants'
+import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { stubComponents } from './stubs'
 
 type Slot = VNode | string | { render: Function } | Function | Component
@@ -194,7 +190,6 @@ export function mount(
       : { ...originalComponent }
 
   const el = document.createElement('div')
-  el.id = MOUNT_ELEMENT_ID
 
   if (options?.attachTo) {
     let to: Element | null


### PR DESCRIPTION
Related: https://github.com/vuejs/vue-test-utils-next/issues/219

@afontcu seems we can remove this id. I am not sure about the div - what should we be attaching to?

Also, does testing library use `attachTo` by default? We need *something* to mount on - if you are using attachTo, however, maybe we can use that element to mount on, instead of creating our own DIV here?