### PR TITLE
Add ESM browser build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,11 +21,13 @@ function createEntry(options) {
     isBrowser
   } = options
 
+  const isEsmBrowser = format === 'es' && isBrowser
+
   const config = {
     input,
     external: [
       'vue',
-      '@vue/compiler-dom',
+      isEsmBrowser ? '@vue/compiler-dom/dist/compiler-dom.esm-browser'  : '@vue/compiler-dom',
     ],
     plugins: [
       replace({
@@ -47,6 +49,9 @@ function createEntry(options) {
 
   if (format === 'es') {
     config.output.file = pkg.module
+    if (isBrowser) {
+      config.output.file = 'dist/vue-test-utils.esm-browser.js'
+    }
   }
   if (format === 'cjs') {
     config.output.file = pkg.main
@@ -72,6 +77,7 @@ function createEntry(options) {
 
 export default [
   createEntry({ format: 'es', input: 'src/index.ts', isBrowser: false }),
+  createEntry({ format: 'es', input: 'src/index.ts', isBrowser: true }),
   createEntry({ format: 'iife', input: 'src/index.ts', isBrowser: true }),
   createEntry({ format: 'cjs', input: 'src/index.ts', isBrowser: false }),
 ]


### PR DESCRIPTION
Hi!

I'm trying to test `vue 3` using `vite` with `vue-test-utils-next`. There's a missing build for `esm-browser` because `esm-bundler` uses `@vue/compiler-dom` and not `@vue/compiler-dom/dist/compiler-dom.esm-browser` which is needed if you want to run VTU in browser using `vite`.

This PR is a showcase of how this fourth – `vue-test-utils.esm-browser.js` – build could look like.