### PR TITLE
feat: default values for global.config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
 
 interface GlobalConfigOptions {
-  global: GlobalMountOptions
+  global: Required<GlobalMountOptions>
   plugins: {
     VueWrapper: Pluggable<VueWrapper<ComponentPublicInstance>>
     DOMWrapper: Pluggable<DOMWrapper<Element>>
@@ -56,7 +56,15 @@ export const config: GlobalConfigOptions = {
     stubs: {
       transition: true,
       'transition-group': true
-    }
+    },
+    provide: {},
+    components: {},
+    config: {},
+    directives: {},
+    mixins: [],
+    mocks: {},
+    plugins: [],
+    renderStubDefaultSlot: false
   },
   plugins: {
     VueWrapper: new Pluggable(),

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -10,7 +10,10 @@ describe('config', () => {
       mixins: [],
       plugins: [],
       mocks: {},
-      provide: {}
+      provide: {},
+      stubs: {},
+      config: {},
+      renderStubDefaultSlot: false
     }
 
     jest.clearAllMocks()

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -5,12 +5,12 @@ import Hello from './components/Hello.vue'
 describe('config', () => {
   beforeEach(() => {
     config.global = {
-      components: undefined,
-      directives: undefined,
-      mixins: undefined,
-      plugins: undefined,
-      mocks: undefined,
-      provide: undefined
+      components: {},
+      directives: {},
+      mixins: [],
+      plugins: [],
+      mocks: {},
+      provide: {}
     }
 
     jest.clearAllMocks()


### PR DESCRIPTION
This allows users to directly attach global properties like mocks and provide without checking it before:

```js
// this pr removes the need of
config.global.provide = config.global.provide || {}
```