### PR TITLE
Export MountingOptions interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { mount, shallowMount, MountingOptions } from './mount'
+import { mount, shallowMount } from './mount'
+import { MountingOptions } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mount, shallowMount } from './mount'
+import { mount, shallowMount, MountingOptions } from './mount'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
@@ -12,5 +12,6 @@ export {
   VueWrapper,
   DOMWrapper,
   config,
-  flushPromises
+  flushPromises,
+  MountingOptions
 }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,7 +1,6 @@
 import {
   h,
   createApp,
-  VNode,
   defineComponent,
   VNodeNormalizedChildren,
   reactive,
@@ -11,7 +10,6 @@ import {
   ComponentOptionsWithArrayProps,
   ComponentOptionsWithoutProps,
   ExtractPropTypes,
-  Component,
   WritableComputedOptions,
   ComponentPropsOptions,
   AppConfig,
@@ -25,7 +23,7 @@ import {
 } from 'vue'
 
 import { config } from './config'
-import { GlobalMountOptions } from './types'
+import { MountingOptions, Slot } from './types'
 import {
   isFunctionalComponent,
   isObjectComponent,
@@ -41,26 +39,6 @@ import { VueConstructor } from 'vue-class-component'
 
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
-
-type Slot = VNode | string | { render: Function } | Function | Component
-
-type SlotDictionary = {
-  [key: string]: Slot
-}
-
-export interface MountingOptions<Props, Data = {}> {
-  data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
-  props?: Props
-  /** @deprecated */
-  propsData?: Props
-  attrs?: Record<string, unknown>
-  slots?: SlotDictionary & {
-    default?: Slot
-  }
-  global?: GlobalMountOptions
-  attachTo?: HTMLElement | string
-  shallow?: boolean
-}
 
 export type ComputedOptions = Record<
   string,

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -27,7 +27,6 @@ import {
 import { config } from './config'
 import { GlobalMountOptions } from './types'
 import {
-  isClassComponent,
   isFunctionalComponent,
   isObjectComponent,
   mergeGlobalProperties

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -49,7 +49,7 @@ type SlotDictionary = {
   [key: string]: Slot
 }
 
-interface MountingOptions<Props, Data = {}> {
+export interface MountingOptions<Props, Data = {}> {
   data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
   props?: Props
   /** @deprecated */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { Component, ComponentOptions, Directive, Plugin, AppConfig } from 'vue'
+import {
+  Component,
+  ComponentOptions,
+  Directive,
+  Plugin,
+  AppConfig,
+  VNode
+} from 'vue'
 
 interface RefSelector {
   ref: string
@@ -19,14 +26,108 @@ interface NameSelector {
 export type FindComponentSelector = RefSelector | NameSelector | string
 export type FindAllComponentsSelector = NameSelector | string
 
+export type Slot = VNode | string | { render: Function } | Function | Component
+
+type SlotDictionary = {
+  [key: string]: Slot
+}
+
+export interface MountingOptions<Props, Data = {}> {
+  /**
+   * Overrides component's default data. Must be a function.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#data
+   */
+  data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
+  /**
+   * Sets component props when mounted.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#props
+   */
+  props?: Props
+  /**
+   * @deprecated use `data` instead.
+   */
+  propsData?: Props
+  /**
+   * Sets component attributes when mounted.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#attrs
+   */
+  attrs?: Record<string, unknown>
+  /**
+   * Provide values for slots on a component. Slots can be a component
+   * imported from a .vue file or a render function. Providing an
+   * object with a `template` key is not supported.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#slots
+   */
+  slots?: SlotDictionary & {
+    default?: Slot
+  }
+  /**
+   * Provides global mounting options to the component.
+   */
+  global?: GlobalMountOptions
+  /**
+   * Specify where to mount the component.
+   * Can be a valid CSS selector, or an Element connected to the document.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#attachto
+   */
+  attachTo?: HTMLElement | string
+  /**
+   * Automatically stub out all the child components.
+   * @default false
+   * @see https://vue-test-utils.vuejs.org/v2/api/#slots
+   */
+  shallow?: boolean
+}
+
 export type GlobalMountOptions = {
+  /**
+   * Installs plugins on the component.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#plugins
+   */
   plugins?: (Plugin | [Plugin, ...any[]])[]
+  /**
+   * Customizes Vue application global configuration
+   * @see https://v3.vuejs.org/api/application-config.html#application-config
+   */
   config?: Partial<Omit<AppConfig, 'isNativeTag'>> // isNativeTag is readonly, so we omit it
+  /**
+   * Applies a mixin for components under testing.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#mixins
+   */
   mixins?: ComponentOptions[]
+  /**
+   * Mocks a global instance property.
+   * This is designed to mock variables injected by third party plugins, not
+   * Vue's native properties such as $root, $children, etc.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#mocks
+   */
   mocks?: Record<string, any>
+  /**
+   * Provides data to be received in a setup function via `inject`.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#provide
+   */
   provide?: Record<any, any>
+  /**
+   * Registers components globally for components under testing.
+   * @see https://vue-test-utils.vuejs.org/v2/api/#components
+   */
   components?: Record<string, Component | object>
+  /**
+   * Registers a directive globally for components under testing
+   * @see https://vue-test-utils.vuejs.org/v2/api/#directives
+   */
   directives?: Record<string, Directive>
+  /**
+   * Stubs a component for components under testing.
+   * @default "{ transition: true, 'transition-group': true }"
+   * @see https://vue-test-utils.vuejs.org/v2/api/#global-stubs
+   */
   stubs?: Record<any, any>
+  /**
+   * Allows rendering the default slot content, even when using
+   * `shallow` or `shallowMount`.
+   * @default false
+   * @see https://vue-test-utils.vuejs.org/v2/api/#renderstubdefaultslot
+   */
   renderStubDefaultSlot?: boolean
 }


### PR DESCRIPTION
Having `MountingOptions` available in Vue Testing Library will improve greatly the DX of people using the library.