### PR TITLE
Add newer node versions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION

![imatge](https://user-images.githubusercontent.com/9197791/99860464-718a2d80-2b93-11eb-8bfc-9339fee87d88.png)
(source: https://nodejs.org/en/about/releases/)


We could drop node 10 as it is quite old and in maintenance mode, but it's fine I guess.