### PR TITLE
fix(types): Fix mount and shallowMount types

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -38,7 +38,6 @@ import { attachEmitListener } from './emitMixin'
 import { createDataMixin } from './dataMixin'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { stubComponents } from './stubs'
-import { VueConstructor } from 'vue-class-component'
 
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
@@ -74,10 +73,10 @@ export type ObjectEmitsOptions = Record<
 export type EmitsOptions = ObjectEmitsOptions | string[]
 
 // Class component
-export function mount(
-  originalComponent: VueConstructor,
+export function mount<V>(
+  originalComponent: new (...args: any[]) => V,
   options?: MountingOptions<any>
-): VueWrapper<ComponentPublicInstance<any>>
+): VueWrapper<ComponentPublicInstance<V>>
 
 // Functional component with emits
 export function mount<Props, E extends EmitsOptions = {}>(

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -71,11 +71,21 @@ export type ObjectEmitsOptions = Record<
 >
 export type EmitsOptions = ObjectEmitsOptions | string[]
 
-// Class component
+// Class component - no props
+export function mount<V>(
+  originalComponent: {
+    new (...args: any[]): V
+    registerHooks(keys: string[]): void
+  },
+  options?: MountingOptions<any>
+): VueWrapper<ComponentPublicInstance<V>>
+
+// Class component - props
 export function mount<V, P>(
   originalComponent: {
     new (...args: any[]): V
-    props(Props: P)
+    props(Props: P): any
+    registerHooks(keys: string[]): void
   },
   options?: MountingOptions<P>
 ): VueWrapper<ComponentPublicInstance<V>>

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -27,7 +27,6 @@ import {
 import { config } from './config'
 import { GlobalMountOptions } from './types'
 import {
-  isClassComponent,
   isFunctionalComponent,
   isObjectComponent,
   mergeGlobalProperties
@@ -73,9 +72,12 @@ export type ObjectEmitsOptions = Record<
 export type EmitsOptions = ObjectEmitsOptions | string[]
 
 // Class component
-export function mount<V>(
-  originalComponent: new (...args: any[]) => V,
-  options?: MountingOptions<any>
+export function mount<V, P>(
+  originalComponent: {
+    new (...args: any[]): V
+    props(Props: P)
+  },
+  options?: MountingOptions<P>
 ): VueWrapper<ComponentPublicInstance<V>>
 
 // Functional component with emits

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -5,6 +5,7 @@ import {
   FunctionalComponent,
   reactive
 } from 'vue'
+import { Options, Vue } from 'vue-class-component'
 import { mount } from '../src'
 
 const AppWithDefine = defineComponent({
@@ -203,3 +204,25 @@ mount(FunctionalComponentEmit)
 
 // @ts-ignore vue 3.0.2 doesn't work. FIX: https://github.com/vuejs/vue-next/pull/2494
 mount(defineComponent(FunctionalComponentEmit))
+
+// class component
+
+@Options({
+  props: {
+    msg: String
+  }
+})
+class ClassComponent extends Vue {
+  dataText: string = ''
+  get computedMsg(): string {
+    return `Message: ${(this.$props as any).msg}`
+  }
+
+  changeMessage(text: string): void {
+    this.dataText = 'Updated'
+  }
+}
+
+// @ts-expect-error it requires an argument
+expectError(mount(ClassComponent, {}).vm.changeMessage())
+mount(ClassComponent, {}).vm.changeMessage('')

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -119,5 +119,5 @@ class ClassComponent extends Vue {
 }
 
 // @ts-expect-error it requires an argument
-expectError(mount(ClassComponent, {}).vm.changeMessage())
+expectError(shallowMount(ClassComponent, {}).vm.changeMessage())
 shallowMount(ClassComponent, {}).vm.changeMessage('')

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -1,5 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import { defineComponent } from 'vue'
+import { Options, Vue } from 'vue-class-component'
 import { shallowMount } from '../src'
 
 const AppWithDefine = defineComponent({
@@ -99,3 +100,24 @@ expectError(
 shallowMount(AppWithoutProps, {
   props: { b: 'Hello' } as never
 })
+
+// class component
+@Options({
+  props: {
+    msg: String
+  }
+})
+class ClassComponent extends Vue {
+  dataText: string = ''
+  get computedMsg(): string {
+    return `Message: ${(this.$props as any).msg}`
+  }
+
+  changeMessage(text: string): void {
+    this.dataText = 'Updated'
+  }
+}
+
+// @ts-expect-error it requires an argument
+expectError(mount(ClassComponent, {}).vm.changeMessage())
+shallowMount(ClassComponent, {}).vm.changeMessage('')


### PR DESCRIPTION
fix #251

This was caused because `vue-class-component` dependency was not made optional or as a dev, so the import `VueContructor` would always be `any`, making all the `mount` and `shallowMount` to be caught by that overload.


I've removed the dependency on `VueContructor` on the `mount`, made it a bit more generic, this might break if the types changes on the `vue-class-component` (which I think is unlikely) 

@ktsn can you just validate if this overload is enough?
```ts
// Class component - no props
export function mount<V>(
  originalComponent: {
    new (...args: any[]): V
    registerHooks(keys: string[]): void
  },
  options?: MountingOptions<any>
): VueWrapper<ComponentPublicInstance<V>>

// Class component - props
export function mount<V, P>(
  originalComponent: {
    new (...args: any[]): V
    props(Props: P): any
    registerHooks(keys: string[]): void
  },
  options?: MountingOptions<P>
): VueWrapper<ComponentPublicInstance<V>>

```