### PR TITLE
issue-249 feat: stub global components

### DIFF
--- a/src/components/RouterLinkStub.ts
+++ b/src/components/RouterLinkStub.ts
@@ -12,6 +12,6 @@ export const RouterLinkStub = defineComponent({
   },
 
   render() {
-    return h('a', undefined, this.$slots.default())
+    return h('a', undefined, this.$slots?.default?.())
   }
 })

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -410,8 +410,8 @@ export function mount(
   // compnents, too, such as <router-link> and <router-view>
   // so we register those globally.
   // https://github.com/vuejs/vue-test-utils-next/issues/249
-  if (options?.global?.stubs) {
-    for (const [name, stub] of Object.entries(options.global.stubs)) {
+  if (global?.stubs) {
+    for (const [name, stub] of Object.entries(global.stubs)) {
       const tag = hyphenate(name)
       if (stub === true) {
         // default stub.

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -25,7 +25,7 @@ function getSlots(ctx: ComponentPublicInstance): Slots | undefined {
   return !config.renderStubDefaultSlot ? undefined : ctx.$slots
 }
 
-const createStub = ({ name, props }: StubOptions): ComponentOptions => {
+export const createStub = ({ name, props }: StubOptions): ComponentOptions => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -1,4 +1,4 @@
-import { h, ComponentOptions } from 'vue'
+import { h, ComponentOptions, defineComponent } from 'vue'
 
 import { config, mount } from '../../src'
 import Hello from '../components/Hello.vue'
@@ -35,6 +35,29 @@ describe('mounting options: stubs', () => {
     })
 
     expect(wrapper.html()).toBe('<div></div><foo-stub></foo-stub>')
+  })
+
+  // https://github.com/vuejs/vue-test-utils-next/issues/249
+  it('applies stubs globally', () => {
+    const Comp = defineComponent({
+      template: '<div><router-link /><router-view /></div>'
+    })
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          RouterLink: true,
+          RouterView: defineComponent({
+            render() {
+              return h('span')
+            }
+          })
+        }
+      }
+    })
+
+    expect(wrapper.html()).toBe(
+      '<div><router-link-stub></router-link-stub><span></span></div>'
+    )
   })
 
   it('stubs a functional component by its variable declaration name', () => {

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -1,6 +1,6 @@
 import { h, ComponentOptions, defineComponent } from 'vue'
 
-import { config, mount } from '../../src'
+import { config, mount, RouterLinkStub } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
@@ -40,12 +40,13 @@ describe('mounting options: stubs', () => {
   // https://github.com/vuejs/vue-test-utils-next/issues/249
   it('applies stubs globally', () => {
     const Comp = defineComponent({
-      template: '<div><router-link /><router-view /></div>'
+      template: '<div><foo /><router-link to="/foo" /><router-view /></div>'
     })
     const wrapper = mount(Comp, {
       global: {
         stubs: {
-          RouterLink: true,
+          Foo: true,
+          RouterLink: RouterLinkStub,
           RouterView: defineComponent({
             render() {
               return h('span')
@@ -56,8 +57,9 @@ describe('mounting options: stubs', () => {
     })
 
     expect(wrapper.html()).toBe(
-      '<div><router-link-stub></router-link-stub><span></span></div>'
+      '<div><foo-stub></foo-stub><a></a><span></span></div>'
     )
+    expect(wrapper.getComponent(RouterLinkStub).vm.to).toBe('/foo')
   })
 
   it('stubs a functional component by its variable declaration name', () => {


### PR DESCRIPTION
Maybe @cyberb can have some input here too.

This addresses https://github.com/vuejs/vue-test-utils-next/issues/249

At the moment `stubs` will only work for locally registered components. For global ones (like `<router-link>`) you currently must registered a component globally to stub it, eg:

```js
mount(Foo, {
  components: {
    RouterLink: {
     render() { return h('div') }
    }
  }     
})
```

Many people expect this to work (I also do)

```js
mount(Foo, {
  global: {
    stubs: {
      RouterLink: {
       render() { return h('div') }
      }
    }
  }     
})
```

This PR takes anything from `global.stubs` and registers a global stub.