### PR TITLE
types: fix mount infer prop type

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -104,7 +104,10 @@ export function mount<
     Props,
     Defaults
   >,
-  options?: MountingOptions<Props, D>
+  options?: MountingOptions<
+    Partial<Defaults> & Omit<Props & PublicProps, keyof Defaults>,
+    D
+  >
 ): VueWrapper<
   InstanceType<
     DefineComponent<

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -150,7 +150,7 @@ export function mount<
     Extends,
     EE
   >,
-  options?: MountingOptions<PublicProps, D>
+  options?: MountingOptions<Props & PublicProps, D>
 ): VueWrapper<
   ComponentPublicInstance<Props, RawBindings, D, C, M, E, VNodeProps & Props>
 >

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -66,13 +66,13 @@ export function mount<V, P>(
     props(Props: P): any
     registerHooks(keys: string[]): void
   },
-  options?: MountingOptions<P>
+  options?: MountingOptions<P & PublicProps>
 ): VueWrapper<ComponentPublicInstance<V>>
 
 // Functional component with emits
 export function mount<Props, E extends EmitsOptions = {}>(
   originalComponent: FunctionalComponent<Props, E>,
-  options?: MountingOptions<Props>
+  options?: MountingOptions<Props & PublicProps>
 ): VueWrapper<ComponentPublicInstance<Props>>
 
 // Component declared with defineComponent
@@ -150,7 +150,7 @@ export function mount<
     Extends,
     EE
   >,
-  options?: MountingOptions<never, D>
+  options?: MountingOptions<PublicProps, D>
 ): VueWrapper<
   ComponentPublicInstance<Props, RawBindings, D, C, M, E, VNodeProps & Props>
 >
@@ -182,7 +182,7 @@ export function mount<
     EE,
     Props
   >,
-  options?: MountingOptions<Props, D>
+  options?: MountingOptions<Props & PublicProps, D>
 ): VueWrapper<ComponentPublicInstance<Props, RawBindings, D, C, M, E>>
 
 // Component declared with { props: { ... } }
@@ -210,7 +210,7 @@ export function mount<
     Extends,
     EE
   >,
-  options?: MountingOptions<ExtractPropTypes<PropsOptions>, D>
+  options?: MountingOptions<ExtractPropTypes<PropsOptions> & PublicProps, D>
 ): VueWrapper<
   ComponentPublicInstance<
     ExtractPropTypes<PropsOptions>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ import {
   Directive,
   Plugin,
   AppConfig,
-  VNode
+  VNode,
+  VNodeProps
 } from 'vue'
 
 interface RefSelector {
@@ -32,7 +33,14 @@ type SlotDictionary = {
   [key: string]: Slot
 }
 
-export interface MountingOptions<Props, Data = {}> {
+type RawProps = VNodeProps & {
+  // used to differ from a single VNode object as children
+  __v_isVNode?: never
+  // used to differ from Array children
+  [Symbol.iterator]?: never
+} & Record<string, any>
+
+export interface MountingOptions<P, Data = {}> {
   /**
    * Overrides component's default data. Must be a function.
    * @see https://vue-test-utils.vuejs.org/v2/api/#data
@@ -42,11 +50,11 @@ export interface MountingOptions<Props, Data = {}> {
    * Sets component props when mounted.
    * @see https://vue-test-utils.vuejs.org/v2/api/#props
    */
-  props?: Props
+  props?: (RawProps & P) | ({} extends P ? null : never)
   /**
    * @deprecated use `data` instead.
    */
-  propsData?: Props
+  propsData?: P
   /**
    * Sets component attributes when mounted.
    * @see https://vue-test-utils.vuejs.org/v2/api/#attrs

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ type SlotDictionary = {
   [key: string]: Slot
 }
 
+// From vue next
+// https://github.com/vuejs/vue-next/blob/1f2a652a9d2e3bec472fb1786a4c16d6ccfa1fb1/packages/runtime-core/src/h.ts#L53-L58
 type RawProps = VNodeProps & {
   // used to differ from a single VNode object as children
   __v_isVNode?: never
@@ -40,7 +42,7 @@ type RawProps = VNodeProps & {
   [Symbol.iterator]?: never
 } & Record<string, any>
 
-export interface MountingOptions<P, Data = {}> {
+export interface MountingOptions<Props, Data = {}> {
   /**
    * Overrides component's default data. Must be a function.
    * @see https://vue-test-utils.vuejs.org/v2/api/#data
@@ -50,11 +52,11 @@ export interface MountingOptions<P, Data = {}> {
    * Sets component props when mounted.
    * @see https://vue-test-utils.vuejs.org/v2/api/#props
    */
-  props?: (RawProps & P) | ({} extends P ? null : never)
+  props?: (RawProps & Props) | ({} extends Props ? null : never)
   /**
    * @deprecated use `data` instead.
    */
-  propsData?: P
+  propsData?: Props
   /**
    * Sets component attributes when mounted.
    * @see https://vue-test-utils.vuejs.org/v2/api/#attrs

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -45,11 +45,11 @@ expectType<string>(
 // )
 
 // can not receive extra props
-expectError(
-  mount(AppWithDefine, {
-    props: { a: 'Hello', c: 2 }
-  })
-)
+// expectError(
+//   mount(AppWithDefine, {
+//     props: { a: 'Hello', c: 2 }
+//   })
+// )
 
 // wrong prop type should not compile
 expectError(
@@ -76,11 +76,11 @@ expectType<string>(
 )
 
 // can't receive extra props
-expectError(
-  mount(AppWithProps, {
-    props: { a: 'Hello', b: 2 }
-  })
-)
+// expectError(
+//   mount(AppWithProps, {
+//     props: { a: 'Hello', b: 2 }
+//   })
+// )
 
 // wrong prop type should not compile
 expectError(
@@ -109,20 +109,20 @@ expectType<number>(
   }).vm.b
 )
 
-// cannot receive extra props
-// if they pass use object inside
-expectError(
-  mount(
-    {
-      props: ['a']
-    },
-    {
-      props: {
-        b: 2
-      }
-    }
-  )
-)
+// // cannot receive extra props
+// // if they pass use object inside
+// expectError(
+//   mount(
+//     {
+//       props: ['a']
+//     },
+//     {
+//       props: {
+//         b: 2
+//       }
+//     }
+//   )
+// )
 
 const AppWithoutProps = {
   template: ''
@@ -150,7 +150,7 @@ expectError((props: { a: 1 }) => {}, {
 })
 
 expectType<number>(
-  mount((props: { a: 1 }, ctx) => {}, {
+  mount((props: { a: number }, ctx) => {}, {
     props: {
       a: 22
     }
@@ -226,3 +226,43 @@ class ClassComponent extends Vue {
 // @ts-expect-error it requires an argument
 expectError(mount(ClassComponent, {}).vm.changeMessage())
 mount(ClassComponent, {}).vm.changeMessage('')
+
+// default props
+const Foo = defineComponent({
+  props: {
+    bar: Boolean,
+    baz: String
+  },
+  template: ''
+})
+
+mount(Foo, {
+  props: {
+    baz: 'hello'
+  }
+})
+
+mount(Foo, {
+  props: {
+    bar: true
+  }
+})
+
+expectError(
+  mount(
+    defineComponent({
+      props: {
+        baz: String,
+        bar: {
+          type: Boolean,
+          required: true
+        }
+      }
+    }),
+    {
+      props: {
+        baz: 'hello'
+      }
+    }
+  )
+)

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -44,12 +44,10 @@ expectType<string>(
 //   })
 // )
 
-// can not receive extra props
-// expectError(
-//   mount(AppWithDefine, {
-//     props: { a: 'Hello', c: 2 }
-//   })
-// )
+// allow extra props, like using `h()`
+mount(AppWithDefine, {
+  props: { a: 'Hello', c: 2 }
+})
 
 // wrong prop type should not compile
 expectError(
@@ -75,12 +73,9 @@ expectType<string>(
   }).vm.a
 )
 
-// can't receive extra props
-// expectError(
-//   mount(AppWithProps, {
-//     props: { a: 'Hello', b: 2 }
-//   })
-// )
+mount(AppWithProps, {
+  props: { a: 'Hello', b: 2 }
+})
 
 // wrong prop type should not compile
 expectError(
@@ -109,20 +104,17 @@ expectType<number>(
   }).vm.b
 )
 
-// // cannot receive extra props
-// // if they pass use object inside
-// expectError(
-//   mount(
-//     {
-//       props: ['a']
-//     },
-//     {
-//       props: {
-//         b: 2
-//       }
-//     }
-//   )
-// )
+// allow extra props, like using `h()`
+mount(
+  {
+    props: ['a']
+  },
+  {
+    props: {
+      b: 2
+    }
+  }
+)
 
 const AppWithoutProps = {
   template: ''

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -120,16 +120,9 @@ const AppWithoutProps = {
   template: ''
 }
 
-// can't receive extra props
-expectError(
-  mount(AppWithoutProps, {
-    props: { b: 'Hello' }
-  })
-)
-
-// except if explicitly cast
+// allow extra props, like using `h()`
 mount(AppWithoutProps, {
-  props: { b: 'Hello' } as never
+  props: { b: 'Hello' }
 })
 
 // Functional tests

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -21,12 +21,10 @@ let wrapper = shallowMount(AppWithDefine, {
 // vm is properly typed
 expectType<string>(wrapper.vm.a)
 
-// // can not receive extra props
-// expectError(
-//   shallowMount(AppWithDefine, {
-//     props: { a: 'Hello', c: 2 }
-//   })
-// )
+// allow extra props, like using `h()`
+shallowMount(AppWithDefine, {
+  props: { a: 'Hello', c: 2 }
+})
 
 // wrong prop type should not compile
 expectError(
@@ -53,12 +51,10 @@ expectType<string>(
   }).vm.a
 )
 
-// // can't receive extra props
-// expectError(
-//   shallowMount(AppWithProps, {
-//     props: { a: 'Hello', b: 2 }
-//   })
-// )
+// allow extra props, like using `h()`
+shallowMount(AppWithProps, {
+  props: { a: 'Hello', b: 2 }
+})
 
 // wrong prop type should not compile
 expectError(

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -85,16 +85,9 @@ const AppWithoutProps = {
   template: ''
 }
 
-// can't receive extra props
-expectError(
-  (wrapper = shallowMount(AppWithoutProps, {
-    props: { b: 'Hello' }
-  }))
-)
-
-// except if explicitly cast
-shallowMount(AppWithoutProps, {
-  props: { b: 'Hello' } as never
+// allow extra props, like using `h()`
+wrapper = shallowMount(AppWithoutProps, {
+  props: { b: 'Hello' }
 })
 
 // class component

--- a/test-dts/shallowMount.d-test.ts
+++ b/test-dts/shallowMount.d-test.ts
@@ -21,12 +21,12 @@ let wrapper = shallowMount(AppWithDefine, {
 // vm is properly typed
 expectType<string>(wrapper.vm.a)
 
-// can not receive extra props
-expectError(
-  shallowMount(AppWithDefine, {
-    props: { a: 'Hello', c: 2 }
-  })
-)
+// // can not receive extra props
+// expectError(
+//   shallowMount(AppWithDefine, {
+//     props: { a: 'Hello', c: 2 }
+//   })
+// )
 
 // wrong prop type should not compile
 expectError(
@@ -53,12 +53,12 @@ expectType<string>(
   }).vm.a
 )
 
-// can't receive extra props
-expectError(
-  shallowMount(AppWithProps, {
-    props: { a: 'Hello', b: 2 }
-  })
-)
+// // can't receive extra props
+// expectError(
+//   shallowMount(AppWithProps, {
+//     props: { a: 'Hello', b: 2 }
+//   })
+// )
 
 // wrong prop type should not compile
 expectError(


### PR DESCRIPTION
fix #237 

Fix issue of not making default properties as optional.

Allow to pass extra props (same behaviour as `h`) 

Commented on tests which prevented extra props.