### PR TITLE
fix: ensure plugins receive options correctly

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,12 +50,7 @@ class Pluggable<Instance = DOMWrapper<Element>> {
       Object.entries(setupResult).forEach(bindProperty)
     }
 
-    // this.installedPlugins.map(invokeSetup).forEach(addAllPropertiesFromSetup)
-    this.installedPlugins
-      .map((plugin) => {
-        return invokeSetup({ handler: plugin.handler, options: plugin.options })
-      })
-      .forEach(addAllPropertiesFromSetup)
+    this.installedPlugins.map(invokeSetup).forEach(addAllPropertiesFromSetup)
   }
 
   /** For testing */

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@ import { ComponentPublicInstance } from 'vue'
 import { GlobalMountOptions } from './types'
 import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
-import { allowedNodeEnvironmentFlags } from 'process'
 
 interface GlobalConfigOptions {
   global: Required<GlobalMountOptions>

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -25,7 +25,6 @@ export class VueWrapper<T extends ComponentPublicInstance> {
     this.rootVM = vm?.$root
     this.componentVM = vm as T
     this.__setProps = setProps
-    // plugins hook
     config.plugins.VueWrapper.extend(this)
   }
 

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -7,72 +7,89 @@ declare module '../../src/vueWrapper' {
     width(): number
     $el: Element
     myMethod(): void
+    greet: (name: string) => string
   }
 }
 
 const textValue = `I'm the innerHTML`
 const mountComponent = () => mount({ template: `<h1>${textValue}</h1>` })
 
-describe('Plugin', () => {
-  describe('#install method', () => {
-    beforeEach(() => {
-      config.plugins.VueWrapper.reset()
-    })
+describe('Plugin#install', () => {
+  beforeEach(() => {
+    config.plugins.VueWrapper.reset()
+  })
 
-    it('extends wrappers with the return values from the install function', () => {
-      const width = 230
-      const plugin = () => ({ width })
-      config.plugins.VueWrapper.install(plugin)
-      const wrapper = mountComponent()
-      expect(wrapper).toHaveProperty('width', width)
-    })
-
-    it('receives the wrapper inside the plugin setup', () => {
-      const plugin = (wrapper: VueWrapper<ComponentPublicInstance>) => {
-        return {
-          $el: wrapper.element // simple aliases
+  it('accepts options', () => {
+    function PluginWithOptions(
+      wrapper: VueWrapper<ComponentPublicInstance>,
+      options: Record<string, string>
+    ) {
+      return {
+        greet: (name: string) => {
+          return `${options.msg}, ${name}`
         }
       }
-      config.plugins.VueWrapper.install(plugin)
-      const wrapper = mountComponent()
-      expect(wrapper.$el.innerHTML).toEqual(textValue)
+    }
+    config.plugins.VueWrapper.install(PluginWithOptions, { msg: 'Hello' })
+
+    const wrapper = mountComponent()
+    // @ts-ignore
+    expect(wrapper.greet('Lachlan')).toBe('Hello, Lachlan')
+  })
+
+  it('extends wrappers with the return values from the install function', () => {
+    const width = 230
+    const plugin = () => ({ width })
+    config.plugins.VueWrapper.install(plugin)
+    const wrapper = mountComponent()
+    expect(wrapper).toHaveProperty('width', width)
+  })
+
+  it('receives the wrapper inside the plugin setup', () => {
+    const plugin = (wrapper: VueWrapper<ComponentPublicInstance>) => {
+      return {
+        $el: wrapper.element // simple aliases
+      }
+    }
+    config.plugins.VueWrapper.install(plugin)
+    const wrapper = mountComponent()
+    expect(wrapper.$el.innerHTML).toEqual(textValue)
+  })
+
+  it('supports functions', () => {
+    const myMethod = jest.fn()
+    const plugin = () => ({ myMethod })
+    config.plugins.VueWrapper.install(plugin)
+    mountComponent().myMethod()
+    expect(myMethod).toHaveBeenCalledTimes(1)
+  })
+
+  describe('error states', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
-    it('supports functions', () => {
-      const myMethod = jest.fn()
-      const plugin = () => ({ myMethod })
-      config.plugins.VueWrapper.install(plugin)
-      mountComponent().myMethod()
-      expect(myMethod).toHaveBeenCalledTimes(1)
+    afterAll(() => {
+      // @ts-ignore
+      console.error.mockRestore()
     })
 
-    describe('error states', () => {
-      beforeAll(() => {
-        jest.spyOn(console, 'error').mockImplementation(() => {})
-      })
+    const plugins = [
+      () => false,
+      () => true,
+      () => [],
+      true,
+      false,
+      'property',
+      120
+    ]
 
-      afterAll(() => {
-        // @ts-ignore
-        console.error.mockRestore()
-      })
-
-      const plugins = [
-        () => false,
-        () => true,
-        () => [],
-        true,
-        false,
-        'property',
-        120
-      ]
-
-      it.each(plugins)(
-        'Calling install with %p is handled gracefully',
-        (plugin) => {
-          config.plugins.VueWrapper.install(plugin as any)
-          expect(() => mountComponent()).not.toThrow()
-        }
-      )
-    })
+    it.each(plugins)(
+      'Calling install with %p is handled gracefully',
+      (plugin) => {
+        config.plugins.VueWrapper.install(plugin as any)
+        expect(() => mountComponent()).not.toThrow()
+      }
+    )
   })
 })

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -33,7 +33,6 @@ describe('Plugin#install', () => {
     config.plugins.VueWrapper.install(PluginWithOptions, { msg: 'Hello' })
 
     const wrapper = mountComponent()
-    // @ts-ignore
     expect(wrapper.greet('Lachlan')).toBe('Hello, Lachlan')
   })
 


### PR DESCRIPTION
I noticed you cannot actually access `options` in your plugin, which makes them not very useful. I fixed it.

Recommend reviewing with whitespace OFF, I removed a useless `describe`, which made the diff bigger that it should be.