### PR TITLE
fix: spy on wrapper.vm with Jest

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -441,8 +441,11 @@ export function mount(
   // if not, use the return value from app.mount.
   const appRef = vm.$refs[MOUNT_COMPONENT_REF] as ComponentPublicInstance
   const $vm = Reflect.ownKeys(appRef).length ? appRef : vm
+  // we add `hasOwnProperty` so jest can spy on the proxied vm without throwing
+  $vm.hasOwnProperty = (property) => {
+    return Reflect.has($vm, property)
+  }
   console.warn = warnSave
-
   return createWrapper(app, $vm, setProps)
 }
 

--- a/tests/vm.spec.ts
+++ b/tests/vm.spec.ts
@@ -24,4 +24,25 @@ describe('vm', () => {
 
     expect(wrapper.vm.isEnabled).toBe(false)
   })
+
+  it('allows spying on vm', async () => {
+    const Component = defineComponent({
+      name: 'VTUComponent',
+      template: '<div @click="toggle()">{{ msg }}</div>',
+      setup() {
+        const msg = 'hello'
+        const isEnabled = ref(true)
+        const toggle = () => (isEnabled.value = !isEnabled.value)
+        return { msg, isEnabled, toggle }
+      }
+    })
+
+    const wrapper = mount(Component)
+
+    jest.spyOn(wrapper.vm, 'toggle')
+
+    await wrapper.get('div').trigger('click')
+
+    expect(wrapper.vm.toggle).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Allow to spy on `wrapper.vm` with jest.

Fixes #309 

BLocked by https://github.com/vuejs/vue-next/pull/3105