### PR TITLE
chore: remove @types/estree dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@rollup/plugin-replace": "^2.3.4",
-    "@types/estree": "^0.0.42",
     "@types/jest": "26.0.20",
     "@types/node": "14.14.22",
     "@vue/compiler-sfc": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,11 +1354,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/estree@^0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.42.tgz#8d0c1f480339efedb3e46070e22dd63e0430dd11"
-  integrity sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"


### PR DESCRIPTION
I think this dependency is not necessary. It was introduced in the very first commit on the repo, and I remember needed in my projects as well because of a typing issue in vue-next, but I think this has been solved for quite some time.