### PR TITLE
fix: record emitted events against each wrapper

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -73,7 +73,7 @@ export class VueWrapper<T extends ComponentPublicInstance> {
   emitted<T = unknown>(): Record<string, T[]>
   emitted<T = unknown>(eventName?: string): T[]
   emitted<T = unknown>(eventName?: string): T[] | Record<string, T[]> {
-    return emitted(eventName)
+    return emitted(this.vm, eventName)
   }
 
   html() {

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -77,10 +77,9 @@ describe('emitted', () => {
     expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
   })
 
-  it('should propagate the original event', () => {
-    const Component = defineComponent({
-      name: 'ContextEmit',
-
+  it('should not propagate child events', () => {
+    const Child = defineComponent({
+      name: 'Child',
       setup(props, { emit }) {
         return () =>
           h('div', [
@@ -91,21 +90,26 @@ describe('emitted', () => {
 
     const Parent = defineComponent({
       name: 'Parent',
-
       setup(props, { emit }) {
         return () =>
-          h(Component, { onHello: (...events) => emit('parent', ...events) })
+          h(Child, { onHello: (...events) => emit('parent', ...events) })
       }
     })
     const wrapper = mount(Parent)
+    const childWrapper = wrapper.findComponent(Child)
+
     expect(wrapper.emitted()).toEqual({})
-    expect(wrapper.emitted().hello).toEqual(undefined)
+    expect(childWrapper.emitted()).toEqual({})
 
     wrapper.find('button').trigger('click')
     expect(wrapper.emitted().parent[0]).toEqual(['foo', 'bar'])
+    expect(wrapper.emitted().hello).toEqual(undefined)
+    expect(childWrapper.emitted().hello[0]).toEqual(['foo', 'bar'])
 
     wrapper.find('button').trigger('click')
     expect(wrapper.emitted().parent[1]).toEqual(['foo', 'bar'])
+    expect(wrapper.emitted().hello).toEqual(undefined)
+    expect(childWrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
   })
 
   it('should allow passing the name of an event', () => {

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -1,4 +1,5 @@
 import { defineComponent, FunctionalComponent, h, SetupContext } from 'vue'
+import { Vue } from 'vue-class-component'
 
 import { mount } from '../src'
 
@@ -137,7 +138,7 @@ describe('emitted', () => {
     expect(wrapper.emitted('hello')).toHaveLength(2)
   })
 
-  it('gives a useful warning for functional components', () => {
+  it('captures events emitted by functional components', () => {
     const Component: FunctionalComponent<
       { bar: string; level: number },
       { hello: (foo: string, bar: string) => void }
@@ -153,6 +154,24 @@ describe('emitted', () => {
         level: 1
       }
     })
+
+    wrapper.find('h1').trigger('click')
+    expect(wrapper.emitted('hello')).toHaveLength(1)
+    expect(wrapper.emitted('hello')[0]).toEqual(['foo', 'bar'])
+  })
+
+  it('captures events emitted by class-style components', () => {
+    // Define the component in class-style
+    class Component extends Vue {
+      bar = 'bar'
+      render() {
+        return h(`h1`, {
+          onClick: () => this.$emit('hello', 'foo', this.bar)
+        })
+      }
+    }
+
+    const wrapper = mount(Component, {})
 
     wrapper.find('h1').trigger('click')
     expect(wrapper.emitted('hello')).toHaveLength(1)


### PR DESCRIPTION
fix #352 

Emitted events are recorded against their component uid, so the events retrieved by `emitted()` doesn't contain child events.

Updated one of the tests to probe for this as well.

First stab at any typescript so please let me know if I've committed terrible type sins. :pray: 