### PR TITLE
Add test to confirm config merger

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
 
 interface GlobalConfigOptions {
-  global: Partial<GlobalMountOptions>
+  global: Required<GlobalMountOptions>
   plugins: {
     VueWrapper: Pluggable<VueWrapper<ComponentPublicInstance>>
     DOMWrapper: Pluggable<DOMWrapper<Element>>

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
 
 interface GlobalConfigOptions {
-  global: Required<GlobalMountOptions>
+  global: Partial<GlobalMountOptions>
   plugins: {
     VueWrapper: Pluggable<VueWrapper<ComponentPublicInstance>>
     DOMWrapper: Pluggable<DOMWrapper<Element>>

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -406,7 +406,10 @@ export function mount(
   // stubs
   // even if we are using `mount`, we will still
   // stub out Transition and Transition Group by default.
-  stubComponents(global.stubs, global.renderStubDefaultSlot ? false : options?.shallow)
+  stubComponents(
+    global.stubs,
+    global.renderStubDefaultSlot ? false : options?.shallow
+  )
 
   // users expect stubs to work with globally registered
   // components, too, such as <router-link> and <router-view>

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -406,10 +406,10 @@ export function mount(
   // stubs
   // even if we are using `mount`, we will still
   // stub out Transition and Transition Group by default.
-  stubComponents(global.stubs, options?.shallow)
+  stubComponents(global.stubs, global.renderStubDefaultSlot ? false : options?.shallow)
 
   // users expect stubs to work with globally registered
-  // compnents, too, such as <router-link> and <router-view>
+  // components, too, such as <router-link> and <router-view>
   // so we register those globally.
   // https://github.com/vuejs/vue-test-utils-next/issues/249
   if (global?.stubs) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,10 +31,9 @@ export function mergeGlobalProperties(
     mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
     config: { ...configGlobal.config, ...mountGlobal.config },
     directives: { ...configGlobal.directives, ...mountGlobal.directives },
-    renderStubDefaultSlot:
-      mountGlobal.renderStubDefaultSlot !== undefined
-        ? mountGlobal.renderStubDefaultSlot
-        : configGlobal.renderStubDefaultSlot
+    renderStubDefaultSlot: !!(mountGlobal.renderStubDefaultSlot !== undefined
+      ? mountGlobal.renderStubDefaultSlot
+      : configGlobal.renderStubDefaultSlot)
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,9 +31,10 @@ export function mergeGlobalProperties(
     mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
     config: { ...configGlobal.config, ...mountGlobal.config },
     directives: { ...configGlobal.directives, ...mountGlobal.directives },
-    renderStubDefaultSlot: mountGlobal.renderStubDefaultSlot !== undefined
-      ? mountGlobal.renderStubDefaultSlot
-      : configGlobal.renderStubDefaultSlot
+    renderStubDefaultSlot:
+      mountGlobal.renderStubDefaultSlot !== undefined
+        ? mountGlobal.renderStubDefaultSlot
+        : configGlobal.renderStubDefaultSlot
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
 export function mergeGlobalProperties(
   configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
-): GlobalMountOptions {
+): Required<GlobalMountOptions> {
   const stubs: Record<string, any> = {}
 
   mergeStubs(stubs, configGlobal)
@@ -29,11 +29,11 @@ export function mergeGlobalProperties(
     components: { ...configGlobal.components, ...mountGlobal.components },
     provide: { ...configGlobal.provide, ...mountGlobal.provide },
     mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
-    config: { ...configGlobal.config, ...mountGlobal.config } as Omit<
-      AppConfig,
-      'isNativeTag'
-    >,
-    directives: { ...configGlobal.directives, ...mountGlobal.directives }
+    config: { ...configGlobal.config, ...mountGlobal.config },
+    directives: { ...configGlobal.directives, ...mountGlobal.directives },
+    renderStubDefaultSlot: mountGlobal.renderStubDefaultSlot !== undefined
+      ? mountGlobal.renderStubDefaultSlot
+      : configGlobal.renderStubDefaultSlot
   }
 }
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -47,7 +47,7 @@ describe('config', () => {
       // mount config overrides default config
       expect(comp.find('#default-slot').exists()).toBe(true)
       // user defined config overrides default config
-      expect(comp.findComponent(Hello).exists()).toBe(true);
+      expect(comp.findComponent(Hello).exists()).toBe(true)
     })
   })
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -65,6 +65,34 @@ describe('config', () => {
 
       expect(comp.find('#default-slot').exists()).toBe(true)
     })
+
+    it('should evaluate given option as boolean', () => {
+      // @ts-expect-error
+      let comp = mount(ComponentWithSlots, {
+        slots: {
+          default: '<div id="default-slot" />'
+        },
+        shallow: true,
+        global: {
+          renderStubDefaultSlot: 'truthy'
+        }
+      })
+
+      expect(comp.find('#default-slot').exists()).toBe(true)
+
+      // @ts-expect-error
+      let comp = mount(ComponentWithSlots, {
+        slots: {
+          default: '<div id="default-slot" />'
+        },
+        shallow: true,
+        global: {
+          renderStubDefaultSlot: 0
+        }
+      })
+
+      expect(comp.find('#default-slot').exists()).toBe(false)
+    })
   })
 
   describe('components', () => {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,6 +1,7 @@
 import { h, inject } from 'vue'
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
+import ComponentWithSlots from './components/ComponentWithSlots.vue'
 
 describe('config', () => {
   beforeEach(() => {
@@ -17,6 +18,51 @@ describe('config', () => {
     }
 
     jest.clearAllMocks()
+  })
+
+  describe('config merger', () => {
+    it('should merge the configs in the correct order', () => {
+      config.global.config.globalProperties = {
+        myProp: 1
+      }
+      config.global.components = { Hello }
+
+      const comp = mount(ComponentWithSlots, {
+        slots: {
+          default: '<div id="default-slot" />'
+        },
+        shallow: true,
+        global: {
+          config: {
+            globalProperties: {
+              myProp: 2
+            }
+          },
+          renderStubDefaultSlot: true
+        }
+      })
+
+      // mount config overrides user defined config
+      expect(comp.vm.$.appContext.config.globalProperties.myProp).toBe(2)
+      // mount config overrides default config
+      expect(comp.find('#default-slot').exists()).toBe(true)
+      // user defined config overrides default config
+      expect(comp.vm.$.appContext.components['Hello']).not.toBeUndefined()
+    })
+  })
+
+  describe('renderStubDefaultSlot', () => {
+    const comp = mount(ComponentWithSlots, {
+      slots: {
+        default: '<div id="default-slot" />'
+      },
+      shallow: true,
+      global: {
+        renderStubDefaultSlot: true
+      }
+    })
+
+    expect(comp.find('#default-slot').exists()).toBe(true)
   })
 
   describe('components', () => {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -29,7 +29,7 @@ describe('config', () => {
 
       const comp = mount(ComponentWithSlots, {
         slots: {
-          default: '<div id="default-slot" />'
+          default: '<div id="default-slot" /><Hello />'
         },
         shallow: true,
         global: {
@@ -47,22 +47,24 @@ describe('config', () => {
       // mount config overrides default config
       expect(comp.find('#default-slot').exists()).toBe(true)
       // user defined config overrides default config
-      expect(comp.vm.$.appContext.components['Hello']).not.toBeUndefined()
+      expect(comp.findComponent(Hello).exists()).toBe(true);
     })
   })
 
   describe('renderStubDefaultSlot', () => {
-    const comp = mount(ComponentWithSlots, {
-      slots: {
-        default: '<div id="default-slot" />'
-      },
-      shallow: true,
-      global: {
-        renderStubDefaultSlot: true
-      }
-    })
+    it('should override shallow option when set to true', () => {
+      const comp = mount(ComponentWithSlots, {
+        slots: {
+          default: '<div id="default-slot" />'
+        },
+        shallow: true,
+        global: {
+          renderStubDefaultSlot: true
+        }
+      })
 
-    expect(comp.find('#default-slot').exists()).toBe(true)
+      expect(comp.find('#default-slot').exists()).toBe(true)
+    })
   })
 
   describe('components', () => {


### PR DESCRIPTION
linked #373 

I don't see why this should be required when trying to set up a single thing in the config. The user provided config is merged with the defaults: https://github.com/vuejs/vue-test-utils-next/blob/master/src/mount.ts#L322
Set it to `Partial` in case something will be required in the `GlobalMountOptions` down the line.

Edit:
This has stemmed from a confusion on how to use the the global config. Added a test to confirm how configs get merged.
+found and fixed an issue with renderStubDefaultSlot