### PR TITLE
fix: remove the browser entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0-rc.0",
   "license": "MIT",
   "main": "dist/vue-test-utils.cjs.js",
-  "browser": "dist/vue-test-utils.browser.js",
   "unpkg": "dist/vue-test-utils.browser.js",
   "types": "dist/index.d.ts",
   "module": "dist/vue-test-utils.esm-bundler.js",


### PR DESCRIPTION
When this entry is in, webpack never picks up on the module one,
which makes it go the wrong way. Since VTU is meant to be used in
Jest/Webpack/Rollup/Vite we shuold avoid breaking those.

I matched the exports of vue and vite here.