### PR TITLE
fix: record native events against each wrapper they bubble through

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -33,23 +33,23 @@ export const attachEmitListener = () => {
   setDevtoolsHook(createDevTools(events))
 }
 
+// devtools hook only catches Vue component custom events
 function createDevTools(events: Events): any {
   return {
     emit(eventType, ...payload) {
       if (eventType !== DevtoolsHooks.COMPONENT_EMIT) return
 
       const [rootVM, componentVM, event, eventArgs] = payload
-      recordEvent(events, componentVM, event, eventArgs)
+      recordEvent(componentVM, event, eventArgs)
     }
   } as Partial<typeof devtools>
 }
 
-function recordEvent(
-  events: Events,
+export const recordEvent = (
   vm: ComponentInternalInstance,
   event: string,
   args: unknown[]
-): void {
+): void => {
   // Functional component wrapper creates a parent component
   let wrapperVm = vm
   while (typeof wrapperVm?.type === 'function') wrapperVm = wrapperVm.parent!

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -1,5 +1,7 @@
 import { ComponentPublicInstance, nextTick, App } from 'vue'
 import { ShapeFlags } from '@vue/shared'
+// @ts-ignore todo - No DefinitelyTyped package exists for this
+import eventTypes from 'dom-event-types'
 
 import { config } from './config'
 import { DOMWrapper } from './domWrapper'
@@ -50,13 +52,10 @@ export class VueWrapper<T extends ComponentPublicInstance> {
     if (!vm) return
 
     const element = this.element
-    for (let key in element) {
-      if (/^on/.test(key)) {
-        const eventName = key.slice(2)
-        element.addEventListener(eventName, (...args) => {
-          recordEvent(vm.$, eventName, args)
-        })
-      }
+    for (let eventName of Object.keys(eventTypes)) {
+      element.addEventListener(eventName, (...args) => {
+        recordEvent(vm.$, eventName, args)
+      })
     }
   }
 

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -1,4 +1,10 @@
-import { defineComponent, FunctionalComponent, h, SetupContext } from 'vue'
+import {
+  defineComponent,
+  FunctionalComponent,
+  getCurrentInstance,
+  h,
+  SetupContext
+} from 'vue'
 import { Vue } from 'vue-class-component'
 
 import { mount } from '../src'
@@ -242,5 +248,30 @@ describe('emitted', () => {
     }
     const wrapper = mount(Comp)
     expect(wrapper.emitted().foo).toBeTruthy()
+  })
+
+  it('captures composition event', async () => {
+    const useCommonBindings = () => {
+      const onCompositionStart = (evt: CompositionEvent) => {
+        const instance = getCurrentInstance()!
+        instance.emit('compositionStart', evt)
+      }
+      return { onCompositionStart }
+    }
+    const IxInput = defineComponent({
+      setup() {
+        return useCommonBindings()
+      },
+      template: `<input @compositionstart="(evt) => $emit('compositionStart', evt)" />`
+    })
+
+    const wrapper = mount({
+      components: { IxInput },
+      template: `<ix-input />`
+    })
+
+    await wrapper.find('input').trigger('compositionstart')
+
+    expect(wrapper.emitted().compositionstart).not.toBe(undefined)
   })
 })


### PR DESCRIPTION
fix #391 

This is pretty ugly on a few levels and I think it needs some cleaning up, but I think it addresses the issue. Maybe going back to the old mixin is a better idea for native events, I think I'll leave that up to you because you know the history a bit better.

I added a test that covers I think a basic exploration of the problem being solved.

Again, I'm an absolute TS novice, :pray: for me.

Looking at this code again, do we need to add a way to clear events similar to jest's `mockClear()`?