### PR TITLE
docs: Cleanup and update API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Get started with the [documentation](https://next.vue-test-utils.vuejs.org/).
 
 ## Coming from Vue 2 + Vue Test Utils?
 
-We are working on [some documentation to help people migrate](https://vue-test-utils.vuejs.org/v2/guide/migration.html).
+We plan on work on [some documentation to help people migrate](https://next.vue-test-utils.vuejs.org/migration/).
 
 At this point you will have better luck trying this out with a brand new Vue 3 app, as opposed to upgrading an existing Vue 2 app. Feedback and bug reports are welcome!
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -2,7 +2,6 @@
 
 /** @type {UserConfig} */
 const config = {
-  // base: '/v2/',
   title: 'Vue Test Utils for Vue 3',
   description: 'The documentation for the official Vue Test Utils',
   locales: {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -8,7 +8,7 @@ const config = {
   locales: {
     '/': {
       lang: 'en-US',
-      title: 'Vue Test Utils (2.0.0-beta.14)'
+      title: 'Vue Test Utils (2.0.0-rc.0)'
     }
   },
   head: [['link', { rel: 'icon', href: `/logo.png` }]],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,13 +1,14 @@
+const package = require('../../package.json')
 /** @typedef {import('vitepress').UserConfig} UserConfig */
 
 /** @type {UserConfig} */
 const config = {
-  title: 'Vue Test Utils for Vue 3',
-  description: 'The documentation for the official Vue Test Utils',
+  title: `Vue Test Utils for Vue 3 (${package.version})`,
+  description: 'The documentation for the official Vue Test Utils for Vue 3',
   locales: {
     '/': {
       lang: 'en-US',
-      title: 'Vue Test Utils (2.0.0-rc.0)'
+      title: `Vue Test Utils for Vue 3 (${package.version})`
     }
   },
   head: [['link', { rel: 'icon', href: `/logo.png` }]],

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1628,10 +1628,9 @@ interface MountingOptions<Props, Data = {}> {
   props?: (RawProps & Props) | ({} extends Props ? null : never)
   slots?: { [key: string]: Slot } & { default?: Slot }
   global?: GlobalMountOptions
-  shallow?: boolean
 }
 
-function mount(Component, options?: MountingOptions): VueWrapper
+function shallowMount(Component, options?: MountingOptions): VueWrapper
 ```
 
 **Details:**

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -68,18 +68,21 @@ document.body.innerHTML = `
   </div>
 `
 
+const Component = {
+  template: `<p>Vue Component</p>`
+}
+
 test('mounts on a specific element', () => {
   const wrapper = mount(Component, {
     attachTo: document.getElementById('app')
   })
 
-  console.log(document.body.innerHTML)
-  /*
-   * <div>
-   *   <h1>Non Vue app</h1>
-   *   <div>Vue Component</div>
-   * </div>
-   */
+  expect(document.body.innerHTML).toBe(`
+  <div>
+    <h1>Non Vue app</h1>
+    <div id="app"><div data-v-app=""><p>Vue Component</p></div></div>
+  </div>
+`)
 })
 ```
 
@@ -96,7 +99,7 @@ attrs?: Record<string, unknown>
 **Details:**
 
 ```js
-test('assigns attributes', () => {
+test('attrs', () => {
   const wrapper = mount(Component, {
     attrs: {
       id: 'hello',
@@ -111,7 +114,7 @@ test('assigns attributes', () => {
 })
 ```
 
-Notice that setting a prop will always trump an attribute:
+Notice that setting a defined prop will always trump an attribute:
 
 ```js
 test('attribute is overridden by a prop with the same name', () => {
@@ -145,14 +148,14 @@ data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
 
 ```vue
 <template>
-  <div>Foo is {{ foo }}</div>
+  <div>Hello {{ message }}</div>
 </template>
 
 <script>
 export default {
   data() {
     return {
-      foo: 'foo'
+      message: 'everyone'
     }
   }
 }
@@ -162,16 +165,16 @@ export default {
 `Component.spec.js`:
 
 ```js
-test('overrides data', () => {
+test('data', () => {
   const wrapper = mount(Component, {
     data() {
       return {
-        foo: 'bar'
+        message: 'world'
       }
     }
   })
 
-  expect(wrapper.html()).toContain('Foo is bar')
+  expect(wrapper.html()).toContain('Hello world')
 })
 ```
 
@@ -234,15 +237,15 @@ slots?: { [key: string]: Slot } & { default?: Slot }
 
 **Details:**
 
-Slots can be a component imported from a `.vue` file or a render function. Currently providing an object with a `template` key is not supported.
+Slots can be a string, a component imported from a `.vue` file or a render function. Currently providing an object with a `template` key is not supported.
 
 `Component.vue`:
 
 ```vue
 <template>
-  <slot name="foo" />
+  <slot name="first" />
   <slot />
-  <slot name="bar" />
+  <slot name="second" />
 </template>
 ```
 
@@ -255,13 +258,12 @@ test('renders slots content', () => {
   const wrapper = mount(Component, {
     slots: {
       default: 'Default',
-      foo: h('h1', {}, 'Named Slot'),
-      bar: Bar
+      first: h('h1', {}, 'Named Slot'),
+      second: Bar
     }
   })
 
-  console.log(wrapper.html())
-  // logs '<h1>Named Slot</h1>Default<div>Bar</div>'
+  expect(wrapper.html()).toBe('<h1>Named Slot</h1>Default<div>Bar</div>')
 })
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,12 +31,12 @@ function mount(Component, options?: MountingOptions): VueWrapper
 ```js
 import { mount } from '@vue/test-utils'
 
-const Hello = {
+const Component = {
   template: '<div>Hello world</div>'
 }
 
 test('mounts a component', () => {
-  const wrapper = mount(Hello, {})
+  const wrapper = mount(Component, {})
 
   expect(wrapper.html()).toContain('Hello world')
 })
@@ -58,19 +58,26 @@ attachTo?: HTMLElement | string
 
 Can be a valid CSS selector, or an [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element) connected to the document.
 
+`Component.vue`:
+
+```vue
+<template>
+  <p>Vue Component</p>
+</template>
+```
+
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 document.body.innerHTML = `
   <div>
     <h1>Non Vue app</h1>
     <div id="app"></div>
   </div>
 `
-
-const Component = {
-  template: `<p>Vue Component</p>`
-}
 
 test('mounts on a specific element', () => {
   const wrapper = mount(Component, {
@@ -98,7 +105,12 @@ attrs?: Record<string, unknown>
 
 **Details:**
 
+`Component.spec.js`:
+
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('attrs', () => {
   const wrapper = mount(Component, {
     attrs: {
@@ -117,6 +129,9 @@ test('attrs', () => {
 Notice that setting a defined prop will always trump an attribute:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('attribute is overridden by a prop with the same name', () => {
   const wrapper = mount(Component, {
     props: {
@@ -165,6 +180,9 @@ export default {
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('data', () => {
   const wrapper = mount(Component, {
     data() {
@@ -212,6 +230,9 @@ export default {
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('props', () => {
   const wrapper = mount(Component, {
     props: {
@@ -249,9 +270,19 @@ Slots can be a string, a component imported from a `.vue` file or a render funct
 </template>
 ```
 
+`Bar.vue`:
+
+```vue
+<template>
+  <div>Bar</div>
+</template>
+```
+
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
 import Bar from './Bar.vue'
 
 test('renders slots content', () => {
@@ -299,14 +330,42 @@ components?: Record<string, Component | object>
 
 **Details:**
 
+`Component.vue`:
+
+```vue
+<template>
+  <div>
+    <global-component />
+  </div>
+</template>
+
+<script>
+import GlobalComponent from '@/components/GlobalComponent'
+
+export default {
+  components: {
+    GlobalComponent
+  }
+}
+</script>
+```
+
+`GlobalComponent.vue`:
+
+```vue
+<template>
+  <div class="global-component">
+    My Global Component
+  </div>
+</template>
+```
+
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
 import GlobalComponent from '@/components/GlobalComponent'
-
-const Component = {
-  template: '<div><global-component/></div>'
-}
+import Component from './Component.vue'
 
 test('global.components', () => {
   const wrapper = mount(Component, {
@@ -328,7 +387,7 @@ Configures [Vue's application global configuration](https://v3.vuejs.org/api/app
 **Signature:**
 
 ```ts
-config?: Partial<Omit<AppConfig, 'isNativeTag'>> // isNativeTag is readonly, so we omit it
+config?: Partial<Omit<AppConfig, 'isNativeTag'>>
 ```
 
 #### global.directives
@@ -346,6 +405,9 @@ directives?: Record<string, Directive>
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 import Directive from '@/directives/Directive'
 
 const Component = {
@@ -378,6 +440,9 @@ mixins?: ComponentOptions[]
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.mixins', () => {
   const wrapper = mount(Component, {
     global: {
@@ -410,7 +475,7 @@ This is designed to mock variables injected by third party plugins, not Vue's na
   <button @click="onClick" />
 </template>
 
-<script>
+<>
 export default {
   methods: {
     onClick() {
@@ -418,12 +483,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.mocks', async () => {
   const $store = {
     dispatch: jest.fn()
@@ -458,6 +526,9 @@ plugins?: (Plugin | [Plugin, ...any[]])[]
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 import myPlugin from '@/plugins/myPlugin'
 
 test('global.plugins', () => {
@@ -474,6 +545,9 @@ To use plugin with options, an array of options can be passed.
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.plugins with options', () => {
   mount(Component, {
     global: {
@@ -502,7 +576,7 @@ provide?: Record<any, any>
   <div>Theme is {{ theme }}</div>
 </template>
 
-<script>
+<>
 import { inject } from 'vue'
 
 export default {
@@ -513,12 +587,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.provide', () => {
   const wrapper = mount(Component, {
     global: {
@@ -537,6 +614,9 @@ If you are using a ES6 `Symbol` for your provide key, you can use it as a dynami
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 const ThemeSymbol = Symbol()
 
 mount(Component, {
@@ -570,13 +650,13 @@ Defaults to **false**.
   <another-component />
 </template>
 
-<script>
+<>
 export default {
   components: {
     AnotherComponent
   }
 }
-</script>
+</>
 ```
 
 `AnotherComponent.vue`
@@ -590,6 +670,9 @@ export default {
 `Component.spec.js`
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.renderStubDefaultSlot', () => {
   const wrapper = mount(ComponentWithSlots, {
     slots: {
@@ -630,18 +713,21 @@ It stubs `Transition` and `TransitionGroup` by default.
   <div><foo /></div>
 </template>
 
-<script>
+<>
 import Foo from '@/Foo.vue'
 
 export default {
   components: { Foo }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('global.stubs using array syntax', () => {
   const wrapper = mount(Component, {
     global: {
@@ -700,19 +786,22 @@ Defaults to **false**.
   <another-component />
 </template>
 
-<script>
+<>
 export default {
   components: {
     AComponent,
     AnotherComponent
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('shallow', () => {
   const wrapper = mount(Component, { shallow: true })
 
@@ -753,7 +842,7 @@ attributes(key?: string): { [key: string]: string } | string
   <div id="foo" :class="className" />
 </template>
 
-<script>
+<>
 export default {
   data() {
     return {
@@ -761,12 +850,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('attributes', () => {
   const wrapper = mount(Component)
 
@@ -800,6 +892,9 @@ Returns an array of classes on an element.
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('classes', () => {
   const wrapper = mount(Component)
 
@@ -828,19 +923,22 @@ The arguments are stored in an array, so you can verify which arguments were emi
 `Component.vue`:
 
 ```vue
-<script>
+<>
 export default {
   created() {
     this.$emit('greet', 'hello')
     this.$emit('greet', 'goodbye')
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('emitted', () => {
   const wrapper = mount(Component)
 
@@ -878,6 +976,9 @@ You can use the same syntax `querySelector` implements.
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('exists', () => {
   const wrapper = mount(Component)
 
@@ -915,6 +1016,9 @@ You can use the same syntax `querySelector` implements. `find` is basically an a
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('find', () => {
   const wrapper = mount(Component)
 
@@ -952,6 +1056,9 @@ findAll(selector: string): DOMWrapper<Element>[]
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('findAll', () => {
   const wrapper = mount(Component)
 
@@ -989,11 +1096,11 @@ findComponent<T extends ComponentPublicInstance>(selector: any): VueWrapper<T>
   <div class="foo">Foo</div>
 </template>
 
-<script>
+<>
 export default {
   name: 'Foo'
 }
-</script>
+</>
 ```
 
 `Component.vue`:
@@ -1003,18 +1110,21 @@ export default {
   <Foo data-test="foo" ref="foo" class="foo" />
 </template>
 
-<script>
+<>
 import Foo from '@/Foo'
 
 export default {
   components: { Foo }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 import Foo from '@/Foo.vue'
 
 test('findComponent', () => {
@@ -1062,6 +1172,9 @@ Similar to `findComponent` but finds all Vue Component instances that match the 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('findAllComponents', () => {
   const wrapper = mount(Component)
 
@@ -1100,6 +1213,9 @@ As a rule of thumb, always use get except when you are asserting something doesn
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('get', () => {
   const wrapper = mount(Component)
 
@@ -1141,11 +1257,11 @@ It is similar to `findComponent`, but `getComponent` throws instead of returning
   <div class="foo">Foo</div>
 </template>
 
-<script>
+<>
 export default {
   name: 'Foo'
 }
-</script>
+</>
 ```
 
 `Component.vue`:
@@ -1155,18 +1271,21 @@ export default {
   <Foo />
 </template>
 
-<script>
+<>
 import Foo from '@/Foo'
 
 export default {
   components: { Foo }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 import Foo from '@/Foo.vue'
 
 test('getComponent', () => {
@@ -1204,6 +1323,9 @@ html(): string
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('html', () => {
   const wrapper = mount(Component)
 
@@ -1267,22 +1389,26 @@ export default {
   <Component truthy :object="{}" string="string" />
 </template>
 
-<script>
+<>
 import Component from '@/Component'
 
 export default {
   components: { Component }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('props', () => {
   const wrapper = mount(Component, {
     global: { stubs: ['Foo'] }
   })
+
   const foo = wrapper.getComponent({ name: 'Foo' })
 
   expect(foo.props('truthy')).toBe(true)
@@ -1323,7 +1449,7 @@ Also, notice that `setData` does not modify composition API `setup()` data.
   <div>Count: {{ count }}</div>
 </template>
 
-<script>
+<>
 export default {
   data() {
     return {
@@ -1331,12 +1457,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('setData', async () => {
   const wrapper = mount(Component)
   expect(wrapper.html()).toContain('Count: 0')
@@ -1347,7 +1476,7 @@ test('setData', async () => {
 })
 ```
 
-::: tip
+::: warning
 You should use `await` when you call `setData` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
@@ -1370,16 +1499,19 @@ setProps(props: Record<string, any>): Promise<void>
   <div>{{ message }}</div>
 </template>
 
-<script>
+<>
 export default {
   props: ['message']
 }
-</script>
+</>
 ```
 
 `Component.spec.js`
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('updates prop', async () => {
   const wrapper = mount(Component, {
     props: {
@@ -1395,7 +1527,7 @@ test('updates prop', async () => {
 })
 ```
 
-::: tip
+::: warning
 You should use `await` when you call `setProps` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
@@ -1427,7 +1559,7 @@ setValue(value: any, prop?: string): Promise<void>
   <div v-if="checked">The input has been checked!</div>
 </template>
 
-<script>
+<>
 export default {
   data() {
     return {
@@ -1436,12 +1568,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('setValue on checkbox', async () => {
   const wrapper = mount(Component)
 
@@ -1460,7 +1595,7 @@ test('setValue on input text', () => {
 })
 ```
 
-::: tip
+::: warning
 You should use `await` when you call `setValue` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
@@ -1487,6 +1622,9 @@ text(): string
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('text', () => {
   const wrapper = mount(Component)
 
@@ -1521,7 +1659,7 @@ trigger(eventString: string, options?: TriggerOptions | undefined): Promise<void
   <button @click="count++">Click me</button>
 </template>
 
-<script>
+<>
 export default {
   data() {
     return {
@@ -1529,12 +1667,15 @@ export default {
     }
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('trigger', async () => {
   const wrapper = mount(Component)
 
@@ -1550,7 +1691,7 @@ Note that `trigger` accepts a second argument to pass options to the triggered E
 await wrapper.trigger('keydown', { keyCode: 65 })
 ```
 
-::: tip
+::: warning
 You should use `await` when you call `trigger` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
@@ -1575,18 +1716,21 @@ It only works on the root `VueWrapper` returned from `mount`. Useful for manual 
   <div />
 </template>
 
-<script>
+<>
 export default {
   unmounted() {
     console.log('unmounted!')
   }
 }
-</script>
+</>
 ```
 
 `Component.spec.js`:
 
 ```js
+import { mount } from '@vue/test-utils'
+import Component from './Component.vue'
+
 test('unmount', () => {
   const wrapper = mount(Component)
 
@@ -1610,8 +1754,10 @@ vm: ComponentPublicInstance
 
 The `Vue` app instance. You can access all of the [instance methods](https://v3.vuejs.org/api/instance-methods.html) and [instance properties](https://v3.vuejs.org/api/instance-properties.html).
 
+Notice that `vm` is only available on a `VueWrapper`.
+
 :::tip
-`vm` is only available on a `VueWrapper`.
+As a rule of thumb, test against the effects of a passed prop (a DOM update, an emitted event, and so on). This will make tests more powerful than simply asserting that a prop is passed.
 :::
 
 ## shallowMount
@@ -1676,36 +1822,47 @@ Instead of configuring global mounting options on a per-test basis, you can conf
 
 An example might be globally mocking the `$t` variable from vue-i18n, globally stubbing out a component, or any other global item:
 
-```js {1,4-6,8-15}
-import { config, mount } from '@vue/test-utils'
-import { h } from 'vue'
+`Component.vue`:
 
-config.global.mocks = {
-  $t: message => message
-}
+```vue
+<template>
+  <p>{{ $t('message') }}</p>
+  <my-component />
+</template>
 
-config.global.stubs = {
-  MyComponent: {
-    name: 'MyComponent'
-    render() {
-      return h('div')
-    }
-  }
-}
+<>
+import MyComponent from '@/components/MyComponent'
 
-const Component = {
+export default {
   components: {
     MyComponent
-  },
-  template: `
-    <p>{{ $t('message') }}</p>
-    <my-component />
-  `
+  }
+}
+</>
+```
+
+`Component.spec.js`:
+
+```js {1,8-10,12-14}
+import { config, mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+
+const MyComponent = defineComponent({
+  template: `<div>My component</div>`
+})
+
+config.global.stubs = {
+  MyComponent
 }
 
-it('uses global config', () => {
+config.global.mocks = {
+  $t: (text) => text
+}
+
+test('config.global', () => {
   const wrapper = mount(Component)
-  console.log(wrapper.html()) // <p>message</p><div></div>
+
+  expect(wrapper.html()).toBe('<p>message</p><div>My component</div>')
 })
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,7 @@ sidebar: auto
 
 # API Reference
 
-## mount()
+## mount
 
 Creates a Wrapper that contains the mounted and rendered Vue component to test.
 
@@ -1584,11 +1584,47 @@ The `Vue` app instance. You can access all of the [instance methods](https://v3.
 `vm` is only available on a `VueWrapper`.
 :::
 
-## Global Config
+## shallowMount
 
-### config
+Creates a Wrapper that contains the mounted and rendered Vue component to test with all children stubbed out.
 
-#### config.global
+**Signature:**
+
+```ts
+interface MountingOptions<Props, Data = {}> {
+  attachTo?: HTMLElement | string
+  attrs?: Record<string, unknown>
+  data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
+  props?: (RawProps & Props) | ({} extends Props ? null : never)
+  slots?: { [key: string]: Slot } & { default?: Slot }
+  global?: GlobalMountOptions
+  shallow?: boolean
+}
+
+function mount(Component, options?: MountingOptions): VueWrapper
+```
+
+**Details:**
+
+`shallowMount` behaves exactly like `mount`, but it stubs all child components by default. Essentially, `shallowMount(Component)` is an alias of `mount(Component, { shallow: true })`.
+
+## flushPromises
+
+**Signature:**
+
+```ts
+flushPromises(): Promise<unknown>
+```
+
+**Details:**
+
+`flushPromises` flushes al resolved promise handlers. This helps make sure async operations such as promises or DOM updates have happened before asserting against them.
+
+Check out [Making HTTP requests](../guide/advanced/http-requests.md) to see an example of `flushPromises` in action.
+
+## config
+
+### config.global
 
 **Signature:**
 

--- a/docs/guide/advanced/async-suspense.md
+++ b/docs/guide/advanced/async-suspense.md
@@ -2,7 +2,9 @@
 
 You may have noticed some other parts of the guide using `await` when calling some methods on `wrapper`, such as `trigger` and `setValue`. What's that all about?
 
-You might know Vue updates reactively; when you change a value, the DOM is automatically updated to reflect the latest value. Vue does this _asynchronously_. In contrast, a test runner like Jest runs _synchronously_. This can cause some surprising results in tests. Let's look at some strategies to ensure Vue is updating the DOM as expected when we run our tests.
+You might know Vue updates reactively: when you change a value, the DOM is automatically updated to reflect the latest value. [Vue does these updates asynchronously](https://v3.vuejs.org/guide/change-detection.html#async-update-queue). In contrast, a test runner like Jest runs _synchronously_. This can cause some surprising results in tests.
+
+Let's look at some strategies to ensure Vue is updating the DOM as expected when we run our tests.
 
 ## A Simple Example - Updating with `trigger`
 
@@ -11,7 +13,7 @@ Let's re-use the `<Counter>` component from [event handling](../essentials/event
 ```js
 const Counter = {
   template: `
-    Count: {{ count }}
+    <p>Count: {{ count }}</p>
     <button @click="handleClick">Increment</button>
   `,
   data() {
@@ -39,11 +41,15 @@ test('increments by 1', () => {
 })
 ```
 
-Surprisingly, this fails! The reason is although `count` is increased, Vue will not update the DOM until the next "tick" or "render cycle". For this reason, the assertion will be called before Vue updates the DOM. This has to do with the concept of "macrotasks", "microtasks" and the JavaScript Event Loop. You can read more details and see a simple example [here](https://javascript.info/event-loop#macrotasks-and-microtasks).
+Surprisingly, this fails! The reason is although `count` is increased, Vue will not update the DOM until the next event loop "tick. For this reason, the assertion (`expect()...`) will be called before Vue updates the DOM.
 
-Implementation details aside, how can we fix this? Vue actually provides a way for us to wait until the DOM is updated: `nextTick`:
+:::tip
+If you want to learn more about this core JavaScript behavior, read about the [Event Loop and its macrotasks and microtasks](https://javascript.info/event-loop#macrotasks-and-microtasks).
+:::
 
-```js {7}
+Implementation details aside, how can we fix this? Vue actually provides a way for us to wait until the DOM is updated: `nextTick`.
+
+```js {1,7}
 import { nextTick } from 'vue'
 
 test('increments by 1', async () => {
@@ -56,7 +62,9 @@ test('increments by 1', async () => {
 })
 ```
 
-Now the test will pass, because we ensure the next "tick" has executed updated the DOM before the assertion runs. Since `await nextTick()` is common, VTU provides a shortcut. Methods than cause the DOM to update, such as `trigger` and `setValue` return `nextTick`! So you can just `await` those directly:
+Now the test will pass, because we ensure the next "tick" has executed updated the DOM before the assertion runs.
+
+Since `await nextTick()` is common, Vue Test Utils provides a shortcut. Methods than cause the DOM to update, such as `trigger` and `setValue` return `nextTick`, so you can just `await` those directly:
 
 ```js {4}
 test('increments by 1', async () => {
@@ -70,7 +78,9 @@ test('increments by 1', async () => {
 
 ## Resolving Other Asynchronous Behavior
 
-`nextTick` is useful to ensure some change in reactivty data is reflected in the DOM before continuing the test. However, sometimes you may want to ensure other, non Vue-related asynchronous behavior is completed, too. A common example is a function that returns a `Promise` that will lead to a change in the DOM. Perhaps you mocked your `axios` HTTP client using `jest.mock`:
+`nextTick` is useful to ensure some change in reactive data is reflected in the DOM before continuing the test. However, sometimes you may want to ensure other, non Vue-related asynchronous behavior is completed, too.
+
+A common example is a function that returns a `Promise`. Perhaps you mocked your `axios` HTTP client using `jest.mock`:
 
 ```js
 jest.mock('axios', () => ({
@@ -78,36 +88,35 @@ jest.mock('axios', () => ({
 }))
 ```
 
-In this case, Vue has no knowledge of the unresolved Promise, so calling `nextTick` will not work - your assertion may run before it is resolved. For scenarios like this, you can use `[flush-promises](https://www.npmjs.com/package/flush-promises)`, which causes all outstanding promises to resolve immediately.
+In this case, Vue has no knowledge of the unresolved Promise, so calling `nextTick` will not work - your assertion may run before it is resolved. For scenarios like this, Vue Test Utils exposes [`flushPromises`](../../api/#flushPromises), which causes all outstanding promises to resolve immediately.
 
 Let's see an example:
 
-```js
-import flushPromises from 'flush-promises'
+```js{1,12}
+import { flushPromises } from '@vue/test-utils'
 import axios from 'axios'
 
 jest.mock('axios', () => ({
-  get: () =>
-    new Promise((resolve) => {
-      resolve({ data: 'some mocked data!' })
-    })
+  get: () => Promise.resolve({ data: 'some mocked data!' })
 }))
 
 test('uses a mocked axios HTTP client and flush-promises', async () => {
   // some component that makes a HTTP called in `created` using `axios`
   const wrapper = mount(AxiosComponent)
 
-  await flushPromises() // axios promise is resolved immediately!
+  await flushPromises() // axios promise is resolved immediately
 
-  // assertions!
+  // after line above, axios request has resolved with the mocked data.
 })
 ```
 
-> If you haven't tested Components with API requests before, you can learn more in [HTTP Requests](./http-requests).
+:::tip
+If you want to learn more about testing requests on Components, make sure you check [Making HTTP Requests](http-requests.md) guide.
+:::
 
 ## Conclusion
 
-- Vue updates the DOM asynchronously; tests runner execute code synchronously.
+- Vue updates the DOM asynchronously; tests runner execute code synchronously instead.
 - Use `await nextTick()` to ensure the DOM has updated before the test continues
-- Functions that might update the DOM, like `trigger` and `setValue` return `nextTick`, so you should `await` them.
-- Use `flush-promises` to resolve any unresolved promises from non-Vue dependencies.
+- Functions that might update the DOM (like `trigger` and `setValue`) return `nextTick`, so you need `await` them.
+- Use `flush-promises` from Vue Test Utils to resolve any unresolved promises from non-Vue dependencies (such as API requests).

--- a/docs/guide/advanced/async-suspense.md
+++ b/docs/guide/advanced/async-suspense.md
@@ -41,7 +41,7 @@ test('increments by 1', () => {
 })
 ```
 
-Surprisingly, this fails! The reason is although `count` is increased, Vue will not update the DOM until the next event loop "tick. For this reason, the assertion (`expect()...`) will be called before Vue updates the DOM.
+Surprisingly, this fails! The reason is although `count` is increased, Vue will not update the DOM until the next event loop tick. For this reason, the assertion (`expect()...`) will be called before Vue updates the DOM.
 
 :::tip
 If you want to learn more about this core JavaScript behavior, read about the [Event Loop and its macrotasks and microtasks](https://javascript.info/event-loop#macrotasks-and-microtasks).

--- a/docs/guide/advanced/slots.md
+++ b/docs/guide/advanced/slots.md
@@ -118,7 +118,7 @@ Note: passing a component using `{ template: '<div /> }` is not supported. Use a
 
 ## Scoped Slots
 
-[Scoped slots](https://v3.vuejs.org/v2/guide/component-slots.html#scoped-slots) and bindings are also supported.
+[Scoped slots](https://v3.vuejs.org/guide/component-slots.html#scoped-slots) and bindings are also supported.
 
 ```js
 const ComponentWithSlots = {

--- a/docs/guide/essentials/easy-to-test.md
+++ b/docs/guide/essentials/easy-to-test.md
@@ -22,7 +22,7 @@ Think in terms of inputs and outputs from a user perspective. Roughly, this is e
 | Events       | Emitted events (using `$emit`)                 |
 | Side Effects | Such as `console.log` or API calls             |
 
-### Everything else is implementation details
+**Everything else is implementation details**.
 
 Notice how this list does not include elements such as internal methods, intermediate states or even data.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,12 @@ type RawProps = VNodeProps & {
 export interface MountingOptions<Props, Data = {}> {
   /**
    * Overrides component's default data. Must be a function.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#data
+   * @see https://next.vue-test-utils.vuejs.org/api/#data
    */
   data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
   /**
    * Sets component props when mounted.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#props
+   * @see https://next.vue-test-utils.vuejs.org/api/#props
    */
   props?: (RawProps & Props) | ({} extends Props ? null : never)
   /**
@@ -59,14 +59,14 @@ export interface MountingOptions<Props, Data = {}> {
   propsData?: Props
   /**
    * Sets component attributes when mounted.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#attrs
+   * @see https://next.vue-test-utils.vuejs.org/api/#attrs
    */
   attrs?: Record<string, unknown>
   /**
    * Provide values for slots on a component. Slots can be a component
    * imported from a .vue file or a render function. Providing an
    * object with a `template` key is not supported.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#slots
+   * @see https://next.vue-test-utils.vuejs.org/api/#slots
    */
   slots?: SlotDictionary & {
     default?: Slot
@@ -78,13 +78,13 @@ export interface MountingOptions<Props, Data = {}> {
   /**
    * Specify where to mount the component.
    * Can be a valid CSS selector, or an Element connected to the document.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#attachto
+   * @see https://next.vue-test-utils.vuejs.org/api/#attachto
    */
   attachTo?: HTMLElement | string
   /**
    * Automatically stub out all the child components.
    * @default false
-   * @see https://vue-test-utils.vuejs.org/v2/api/#slots
+   * @see https://next.vue-test-utils.vuejs.org/api/#slots
    */
   shallow?: boolean
 }
@@ -92,7 +92,7 @@ export interface MountingOptions<Props, Data = {}> {
 export type GlobalMountOptions = {
   /**
    * Installs plugins on the component.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#plugins
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-plugins
    */
   plugins?: (Plugin | [Plugin, ...any[]])[]
   /**
@@ -102,42 +102,42 @@ export type GlobalMountOptions = {
   config?: Partial<Omit<AppConfig, 'isNativeTag'>> // isNativeTag is readonly, so we omit it
   /**
    * Applies a mixin for components under testing.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#mixins
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-mixins
    */
   mixins?: ComponentOptions[]
   /**
    * Mocks a global instance property.
    * This is designed to mock variables injected by third party plugins, not
    * Vue's native properties such as $root, $children, etc.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#mocks
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-mocks
    */
   mocks?: Record<string, any>
   /**
    * Provides data to be received in a setup function via `inject`.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#provide
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-provide
    */
   provide?: Record<any, any>
   /**
    * Registers components globally for components under testing.
-   * @see https://vue-test-utils.vuejs.org/v2/api/#components
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-components
    */
   components?: Record<string, Component | object>
   /**
    * Registers a directive globally for components under testing
-   * @see https://vue-test-utils.vuejs.org/v2/api/#directives
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-directives
    */
   directives?: Record<string, Directive>
   /**
    * Stubs a component for components under testing.
    * @default "{ transition: true, 'transition-group': true }"
-   * @see https://vue-test-utils.vuejs.org/v2/api/#global-stubs
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-stubs
    */
   stubs?: Record<any, any>
   /**
    * Allows rendering the default slot content, even when using
    * `shallow` or `shallowMount`.
    * @default false
-   * @see https://vue-test-utils.vuejs.org/v2/api/#renderstubdefaultslot
+   * @see https://next.vue-test-utils.vuejs.org/api/#global-renderstubdefaultslot
    */
   renderStubDefaultSlot?: boolean
 }


### PR DESCRIPTION
- [x] Add Signatures (TS types). I wasn't 100% sure about where to draw the line. Any feedback is appreciated.
- [x] Add missing docs (shallowMount, flushPromises…).
- [x] Make API docs more consistent.
- [x] Fix links on `MountingOptions`.
- [x] Ensure API page only shows sidebar for API methods (otherwise is way too long). 
 