### PR TITLE
fix: Handle exists() after unmounting

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -40,10 +40,6 @@ export default class BaseWrapper<ElementType extends Element> {
     return textContent(this.element)
   }
 
-  exists() {
-    return true
-  }
-
   async trigger(eventString: string, options?: TriggerOptions) {
     if (options && options['target']) {
       throw Error(

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -21,6 +21,10 @@ export class DOMWrapper<ElementType extends Element>
     return this.element.outerHTML
   }
 
+  exists(): boolean {
+    return true
+  }
+
   find<K extends keyof HTMLElementTagNameMap>(
     selector: K
   ): DOMWrapper<HTMLElementTagNameMap[K]>

--- a/src/interfaces/wrapperLike.ts
+++ b/src/interfaces/wrapperLike.ts
@@ -30,5 +30,7 @@ export default interface WrapperLike {
 
   html(): string
 
+  exists(): boolean
+
   setValue(value: any): Promise<void>
 }

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -87,6 +87,11 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return emitted(this.vm, eventName)
   }
 
+  exists(): boolean {
+    if (!this.parentElement) return false
+    return true
+  }
+
   html() {
     // cover cases like <Suspense>, multiple root nodes.
     if (this.parentElement['__vue_app__']) {
@@ -104,8 +109,9 @@ export class VueWrapper<T extends ComponentPublicInstance>
   ): DOMWrapper<SVGElementTagNameMap[K]>
   find<T extends Element>(selector: string): DOMWrapper<T>
   find(selector: string): DOMWrapper<Element> {
-    // force using the parentElement to allow finding the root element
-    const result = this.parentElement.querySelector(selector)
+    // force using the parentElement to allow finding the root element.
+    // parentElement might not exist (for instance, after unmounting the component)
+    const result = this.parentElement?.querySelector(selector)
     if (result) {
       return new DOMWrapper(result)
     }

--- a/tests/exists.spec.ts
+++ b/tests/exists.spec.ts
@@ -22,4 +22,24 @@ describe('exists', () => {
     const wrapper = mount(Component)
     expect(wrapper.find('#msg').exists()).toBe(true)
   })
+
+  it('returns false when wrapper is destroyed', () => {
+    const compiled = defineComponent({ template: '<div />' })
+    const wrapper = mount(compiled)
+
+    expect(wrapper.exists()).toEqual(true)
+
+    wrapper.unmount()
+
+    expect(wrapper.exists()).toEqual(false)
+  })
+
+  it('returns false when node is destroyed', () => {
+    const compiled = defineComponent({ template: '<div />' })
+    const wrapper = mount(compiled)
+
+    wrapper.unmount()
+
+    expect(wrapper.find('div').exists()).toEqual(false)
+  })
 })


### PR DESCRIPTION
I never use it, but I believe `exists()` should return false after unmounting the component.

(_disclaimer: still trying to find the best signaling that the element is gone_)