### PR TITLE
chore: remove rollup replace warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,10 @@ function createEntry(options) {
     ],
     plugins: [
       replace({
-        "process.env.NODE_ENV": true
+        values: {
+          "process.env.NODE_ENV": "true"
+        },
+        preventAssignment: true
       }),
       resolve(), commonjs(), json()
     ],


### PR DESCRIPTION
Currently we have a warning when building VTU.

```
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
```

`@rollup/plugin-replace` introduced a new option in v2.4.0 to prevent accidental assignements.
See https://github.com/rollup/plugins/blob/master/packages/replace/CHANGELOG.md#v240

This probably does not matter for us, but let's get rid of the warning.