### PR TITLE
Fix non-reactive stub props

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -169,8 +169,10 @@ export function stubComponents(
       // case 1: default stub
       if (stub === true || shallow) {
         const propsDeclaration = type?.props || {}
+        const newStub = createStub({ name, propsDeclaration, props })
+        stubs[name] = newStub
         return [
-          createStub({ name, propsDeclaration, props }),
+          newStub,
           props,
           children,
           patchFlag,

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -111,4 +111,70 @@ describe('props', () => {
     await wrapper.trigger('click')
     expect(wrapper.props('modelValue')).toBe(2)
   })
+
+  it('returns reactive props on a stubbed component', async () => {
+    const Foo = {
+      name: 'Foo',
+      template: 'Foo',
+      props: {
+        foo: String,
+      }
+    }
+    const Component = defineComponent({
+        data: () => ({ foo: "old value" }),
+        template: '<div><foo :foo="foo" /><button @click="buttonClick">Click me</button></div>',
+        methods: { buttonClick() { this.foo = "new value" } },
+        components: { Foo }
+      }
+    )
+
+    const wrapper = mount(Component, {
+      global: {
+        stubs: ['Foo']
+      }
+    })
+    let fooCmp = wrapper.findComponent({ name: 'Foo' })
+
+    expect(fooCmp.props()).toEqual({
+      foo: 'old value'
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(fooCmp.props()).toEqual({
+      foo: 'new value'
+    })
+  })
+
+  it('returns reactive props on a stubbed component shallow case', async () => {
+    const Foo = {
+      name: 'Foo',
+      template: 'Foo',
+      props: {
+        foo: String,
+      }
+    }
+    const Component = defineComponent({
+        data: () => ({ foo: "old value" }),
+        template: '<div><foo :foo="foo" /><button @click="buttonClick">Click me</button></div>',
+        methods: { buttonClick() { this.foo = "new value" } },
+        components: { Foo }
+      }
+    )
+
+    const wrapper = mount(Component, {
+      shallow: true
+    })
+    let fooCmp = wrapper.findComponent({ name: 'Foo' })
+
+    expect(fooCmp.props()).toEqual({
+      foo: 'old value'
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(fooCmp.props()).toEqual({
+      foo: 'new value'
+    })
+  })
 })


### PR DESCRIPTION
As discussed in #362 this is a PR that includes a fix for the non-reactive props of stubs.

This is just the tests and the fix in separate commits. I have not added any comments. I still would like to discuss whether there is another less hacky way to fix this.