### PR TITLE
fix(mount): avoid warning when stubbing

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -420,6 +420,10 @@ export function mount(
   // ref: https://github.com/vuejs/vue-test-utils-next/issues/425
   if (global?.stubs) {
     for (const [name, stub] of Object.entries(global.stubs)) {
+      // removes a previously component with the same name if it exists
+      // and avoids the warning from vue-next
+      // "Component has already been registered in target app."
+      delete app._context.components[name]
       if (stub === true) {
         const stubbed = createStub({ name, props: {} })
         // default stub.

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -4,6 +4,7 @@ import { config, mount, RouterLinkStub } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
+import { createRouter, createWebHistory } from 'vue-router'
 
 describe('mounting options: stubs', () => {
   let configStubsSave = config.global.stubs
@@ -81,6 +82,34 @@ describe('mounting options: stubs', () => {
     expect(wrapper.html()).toEqual(
       '<div><functional-foo-stub></functional-foo-stub></div>'
     )
+  })
+
+  it('does not warn if stubbing an already registered component', () => {
+    // a component with RouterView
+    const Comp = defineComponent({
+      template: '<RouterView />'
+    })
+    // we want to check if Vue does not log a warning because we register RouterView twice
+    jest.spyOn(console, 'warn')
+
+    // let's register the router as a plugin (which registers the RouterView component once)
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [{ path: '/', component: Comp }]
+    })
+    // and let's stub RouterView, which registers RouterView a second time
+    const wrapper = mount(Comp, {
+      global: {
+        plugins: [router],
+        stubs: {
+          RouterView: true
+        }
+      }
+    })
+
+    expect(wrapper.html()).toBe('<router-view-stub></router-view-stub>')
+    // check that no warning was emitted
+    expect(console.warn).not.toHaveBeenCalled()
   })
 
   it('stubs a component without a name', () => {


### PR DESCRIPTION
Now that we "properly" register stubs
(see this commit https://github.com/vuejs/vue-test-utils-next/commit/bb8023fc2dd1757f0358d3a8f2967a1064019540),
a bunch of warning are logged by Vue when a test tries to stub an already registered component.

For example, vue-router-mock register RouterView and then stubs it
(see https://github.com/posva/vue-router-mock/blob/v2/src/injections.ts#L37-L41).
So if you use vue-router-mock (or a similar pattern) in your test, Vue logs:

    [Vue warn]: Component "RouterView" has already been registered in target app.

because when a component is stubbed, we re-register it in VTU-next, and Vue warns us that it might be a mistake.

This is a quite naive fix, as it removes the already registered component before registering the stub.