### PR TITLE
fix: use displayName only for functional components

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -36,9 +36,13 @@ export function matches(
     }
 
     let componentName: string | undefined
-    if ('name' in nodeType || 'displayName' in nodeType) {
-      // match normal component definitions or functional components
-      componentName = nodeType.name || nodeType.displayName
+    if ('name' in nodeType) {
+      // match normal component definitions
+      componentName = nodeType.name
+    }
+    if (!componentName && 'displayName' in nodeType) {
+      // match functional components
+      componentName = nodeType.displayName
     }
     let selectorName = selector.name
 


### PR DESCRIPTION
This fixes one of the issues that arise when bumping to vue 3.0.9.
There is no change in behavior: it just make TypeScript OK with the recent changes in vue-next.