### PR TITLE
fix: allow global components to be stubbed

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -386,8 +386,12 @@ export function mount(
   }
 
   if (global.components) {
-    for (const key of Object.keys(global.components))
-      app.component(key, global.components[key])
+    for (const key of Object.keys(global.components)) {
+      // avoid registering components that are stubbed twice
+      if (!global.stubs[key]) {
+        app.component(key, global.components[key])
+      }
+    }
   }
 
   if (global.directives) {

--- a/tests/mountingOptions/global.components.spec.ts
+++ b/tests/mountingOptions/global.components.spec.ts
@@ -18,4 +18,54 @@ describe('global.components', () => {
 
     expect(wrapper.text()).toBe('Global')
   })
+
+  it('allows global stubs to take precedence without warning', () => {
+    const GlobalComponent = {
+      template: '<div>Global</div>'
+    }
+    const spy = jest.spyOn(console, 'warn')
+    const wrapper = mount(
+      {
+        template: '<div><global-component/></div>'
+      },
+      {
+        global: {
+          components: {
+            GlobalComponent
+          },
+          stubs: { GlobalComponent: true }
+        }
+      }
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+    expect(wrapper.html()).toBe(
+      `<div><global-component-stub></global-component-stub></div>`
+    )
+  })
+
+  it('allows global stubs to be deactivated without warning', () => {
+    const GlobalComponent = {
+      template: '<div>Global</div>'
+    }
+    const spy = jest.spyOn(console, 'warn')
+    const wrapper = mount(
+      {
+        template: '<div><global-component/></div>'
+      },
+      {
+        global: {
+          components: {
+            GlobalComponent
+          },
+          stubs: { GlobalComponent: false }
+        }
+      }
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+    expect(wrapper.text()).toBe('Global')
+  })
 })


### PR DESCRIPTION
Coming from https://github.com/posva/vue-router-mock/issues/96

The warning happens because I do this: https://github.com/posva/vue-router-mock/blob/v2/src/injections.ts#L37-L41

I think this change is useful to toggle stubs with `stubs: {RouterLink: false}`