### PR TITLE
feat: Allow stub out async component without name and without need of async/await

### DIFF
--- a/docs/guide/advanced/stubs-shallow-mount.md
+++ b/docs/guide/advanced/stubs-shallow-mount.md
@@ -83,6 +83,10 @@ test('stubs component', () => {
 
 This will stub out _all_ the `<FetchDataFromApi />` components in the entire render tree, regardless of what level they appear at. That's why it is in the `global` mounting option.
 
+::: tip
+To stub out you can either use the key in `components` or the name of your component. If both are given in `global.stubs` the key will be used first.
+:::
+
 ## Stubbing all children components
 
 Sometimes you might want to stub out _all_ the custom components. For example you might have a component like this:
@@ -137,7 +141,7 @@ If you used VTU V1, you may remember this as `shallowMount`. That method is stil
 
 ## Stubbing an async component
 
-In case you want to stub out an async component, then make sure to provide a name for the component and use this name as stubs key.
+In case you want to stub out an async component, then there are two behaviours. For example, you might have components like this:
 
 ```js
 // AsyncComponent.js
@@ -153,13 +157,35 @@ const App = defineComponent({
   },
   template: '<MyComponent/>'
 })
+```
 
-// App.spec.js
-test('stubs async component', async () => {
+The first behaviour is using the key defined in your component which loads the async component. In this example we used to key "MyComponent".
+It is not required to use `async/await` in the test case, because the component has been stubbed out before resolving.
+
+```js
+test('stubs async component without resolving', () => {
   const wrapper = mount(App, {
     global: {
       stubs: {
-        // Besure to use the name from AsyncComponent and not "MyComponent"
+        MyComponent: true
+      }
+    }
+  })
+
+  expect(wrapper.html()).toBe('<my-component-stub></my-component-stub>')
+})
+```
+
+The second behaviour is using the name of the async component. In this example we used to name "AsyncComponent".
+Now it is required to use `async/await`, because the async component needs to be resolved and then can be stubbed out by the name defined in the async component.
+
+**Make sure you define a name in your async component!**
+
+```js
+test('stubs async component with resolving', async () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
         AsyncComponent: true
       }
     }

--- a/tests/__snapshots__/shallowMount.spec.ts.snap
+++ b/tests/__snapshots__/shallowMount.spec.ts.snap
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`shallowMount renders props for stubbed component in a snapshot 1`] = `<my-label-stub val="username"></my-label-stub>`;
+exports[`shallowMount renders props for stubbed component in a snapshot 1`] = `
+<div>
+  <my-label-stub val="username"></my-label-stub>
+  <async-component-stub></async-component-stub>
+</div>
+`;

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineAsyncComponent, defineComponent } from 'vue'
 import { mount, shallowMount, VueWrapper } from '../src'
 import ComponentWithChildren from './components/ComponentWithChildren.vue'
 import ScriptSetupWithChildren from './components/ScriptSetupWithChildren.vue'
@@ -19,9 +19,14 @@ describe('shallowMount', () => {
       template: '<label :for="val">{{ val }}</label>'
     })
 
+    const AsyncComponent = defineAsyncComponent(async () => ({
+      name: 'AsyncComponentName',
+      template: '<span>AsyncComponent</span>'
+    }))
+
     const Component = defineComponent({
-      components: { MyLabel },
-      template: '<MyLabel val="username" />',
+      components: { MyLabel, AsyncComponent },
+      template: '<div><MyLabel val="username" /><AsyncComponent /></div>',
       data() {
         return {
           foo: 'bar'
@@ -32,7 +37,10 @@ describe('shallowMount', () => {
     const wrapper = shallowMount(Component)
 
     expect(wrapper.html()).toBe(
-      '<my-label-stub val="username"></my-label-stub>'
+      '<div>\n' +
+        '  <my-label-stub val="username"></my-label-stub>\n' +
+        '  <async-component-stub></async-component-stub>\n' +
+        '</div>'
     )
     expect(wrapper).toMatchSnapshot()
   })


### PR DESCRIPTION
I have dealt some more with stubbing out an async component.
With this PR I want to allow to stub out the async component without the need to provide a name and use `async/await`.

The async component can now be stubbed out the same way as a sync component:
```js
// AsyncComponent.js
export default defineComponent({
  name: 'AsyncComponent', // Not required any more
  template: '<span>AsyncComponent</span>'
})

// App.js
const App = defineComponent({
  components: {
    MyComponent: defineAsyncComponent(() => import('./AsyncComponent'))
  },
  template: '<MyComponent/>'
})

// App.spec.js
test('stubs async component without resolving', () => {
  const wrapper = mount(App, {
    global: {
      stubs: {
        MyComponent: true
      }
    }
  })
  
  // No need to use await flushPromises()
  expect(wrapper.html()).toBe('<my-component-stub></my-component-stub>')
})
```

It can also be stubbed out like before using the name rather than the key.

```js
// AsyncComponent.js
export default defineComponent({
  name: 'AsyncComponent',
  template: '<span>AsyncComponent</span>'
})

// App.js
const App = defineComponent({
  components: {
    MyComponent: defineAsyncComponent(() => import('./AsyncComponent'))
  },
  template: '<MyComponent/>'
})

// App.spec.js
test('stubs async component with resolving', async () => {
  const wrapper = mount(App, {
    global: {
      stubs: {
        AsyncComponent: true
      }
    }
  })

  // flushPromises now required
  await flushPromises()

  expect(wrapper.html()).toBe('<async-component-stub></async-component-stub>')
})
```

I'm not pretty sure about the detection of the `AsyncComponentWrapper`. Maybe someone got a better way.
```js
const getAsyncComponentName = (
  type: VNodeTypes,
  props: ({ [key: string]: unknown } & VNodeProps) | null | undefined
): string | null => {
  // Async components will be mounted as AsyncComponentWrapper
  if (!isMountedComponent(type, props)) return null

  // AsyncComponentWrapper may only contain one component
  const components = (type as ComponentOptions).components as Record<
    string,
    ComponentOptions
  >
  if (!components || Object.keys(components).length !== 1) return null

  const asyncComponentName = Object.keys(components)[0]
  const asyncComponent = components[asyncComponentName]

  // Is AsyncComponentWrapper?
  if (
    !asyncComponent.__asyncLoader ||
    asyncComponent.name !== 'AsyncComponentWrapper'
  )
    return null

  return asyncComponentName
}
```
