### PR TITLE
fix: don't record native events that are included in emits option (#444)

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -56,8 +56,14 @@ export class VueWrapper<T extends ComponentPublicInstance>
     const vm = this.vm
     if (!vm) return
 
+    const emits = vm.$options.emits || []
     const element = this.element
     for (let eventName of Object.keys(eventTypes)) {
+      // if a component includes events in 'emits' with the same name as native
+      // events, the native events with that name should be ignored
+      // @see https://github.com/vuejs/rfcs/blob/master/active-rfcs/0030-emits-option.md#fallthrough-control
+      if (emits.includes(eventName)) continue
+
       element.addEventListener(eventName, (...args) => {
         recordEvent(vm.$, eventName, args)
       })

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -175,6 +175,26 @@ describe('emitted', () => {
     expect(childWrapper.emitted().hi[1]).toEqual(['foo', 'bar'])
   })
 
+  it('should not propagate native events defined in emits', () => {
+    const HiButton = defineComponent({
+      name: 'HiButton',
+      emits: ['hi', 'click'],
+      setup(props, { emit }) {
+        return () =>
+          h('div', [h('button', { onClick: () => emit('hi', 'foo', 'bar') })])
+      }
+    })
+
+    const wrapper = mount(HiButton)
+
+    expect(wrapper.emitted()).toEqual({})
+
+    wrapper.find('button').trigger('click')
+
+    expect(wrapper.emitted().hi[0]).toEqual(['foo', 'bar'])
+    expect(wrapper.emitted().click).toEqual(undefined)
+  })
+
   it('should allow passing the name of an event', () => {
     const Component = defineComponent({
       name: 'ContextEmit',


### PR DESCRIPTION
fix #444 

I experimented with attaching the native event listener to the component's parentElement, hoping that vue's native event emitting behaviour would provide what we really want to collect, but this broke a couple of other tests.

Instead I opted to simply filter out any native event names that appear in `emits` while attaching our enumerated native event listeners. The added test passes and nothing else breaks so I think this should be adequate to fix #444.