### PR TITLE
refactor: avoid using import * in slots

### DIFF
--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -11,7 +11,9 @@ import type { SetupContext } from 'vue'
 
 export function processSlot(
   source = '',
-  Vue = {
+  // this parameter is only used for testing
+  // typing it does not matter much
+  Vue: unknown = {
     toDisplayString,
     createVNode,
     resolveComponent,

--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -1,8 +1,25 @@
 import { compile } from '@vue/compiler-dom'
-import * as vue from 'vue'
+import {
+  toDisplayString,
+  createVNode,
+  resolveComponent,
+  withCtx,
+  openBlock,
+  createBlock
+} from 'vue'
 import type { SetupContext } from 'vue'
 
-export function processSlot(source = '', Vue = vue) {
+export function processSlot(
+  source = '',
+  Vue = {
+    toDisplayString,
+    createVNode,
+    resolveComponent,
+    withCtx,
+    openBlock,
+    createBlock
+  }
+) {
   let template = source.trim()
   const hasWrappingTemplate = template && template.startsWith('<template')
 
@@ -18,6 +35,7 @@ export function processSlot(source = '', Vue = vue) {
       prefixIdentifiers: __BROWSER__
     }
   )
+
   const createRenderFunction = new Function(
     'Vue',
     __BROWSER__ ? `'use strict';\n${code}` : code

--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -13,9 +13,9 @@ export function processSlot(
   source = '',
   // this parameter is only used for testing
   // typing it does not matter much
-  Vue: unknown = {
+  Vue = {
     toDisplayString,
-    createVNode,
+    createVNode: createVNode as unknown,
     resolveComponent,
     withCtx,
     openBlock,


### PR DESCRIPTION
necessary for compat with vitejs

ESBuild hates `import *`. Since it looks at most files independently from each other (for speed). It can easily fail to understand what `import * as Vue from 'vue'` means.

I will create an issue on vitejs but in the meantime, this fixes the issues of @cypress/vite-dev-server with vue-demi.