### PR TITLE
feat: vModel mounting option

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -16,6 +16,7 @@ interface MountingOptions<Props, Data = {}> {
   attrs?: Record<string, unknown>
   data?: () => {} extends Data ? any : Data extends object ? Partial<Data> : any
   props?: (RawProps & Props) | ({} extends Props ? null : never)
+  vModel?: (RawProps & Props) | ({} extends Props ? null : never)
   slots?: { [key: string]: Slot } & { default?: Slot }
   global?: GlobalMountOptions
   shallow?: boolean
@@ -198,7 +199,7 @@ test('data', () => {
 
 ### props
 
-Sets props on a component when mounted.
+Sets props on a component when mounted. Note that if you want to update a prop passed as `v-model`, [you should use `vModel`](/api/#vmodel).
 
 **Signature:**
 
@@ -241,6 +242,62 @@ test('props', () => {
   })
 
   expect(wrapper.html()).toContain('Count: 5')
+})
+```
+
+### vModel
+
+Similar to `props`, but values passed to `vModel` will be updated when using the [`update:modelValue` syntax](https://v3.vuejs.org/guide/component-custom-events.html#v-model-arguments).
+
+**Signature:**
+
+```ts
+vModel?: (RawProps & Props) | ({} extends Props ? null : never)
+```
+
+**Details:**
+
+`Component.vue`:
+
+```vue
+<template>
+  <input @input="updateValue" />
+  {{ color }}
+</template>
+
+<script>
+export default {
+  props: {
+    color: String
+  },
+  methods: {
+    handle($event) {
+      this.$emit('update:color', $event.target.value)
+    }
+  }
+}
+</script>
+```
+
+`Component.spec.js`:
+
+```js
+it('updates v-model automatically', async () => {
+  const wrapper = mount(Component, {
+    vModel: {
+      color: 'red'
+    }
+  })
+
+  expect(wrapper.html()).toContain('red')
+
+  // update the input value
+  wrapper.find('input').element.value = 'blue'
+  // trigger the input event
+  await wrapper.find('input').trigger('input')
+
+  // value is updated and reflected in the DOM
+  expect(wrapper.html()).toContain('blue')
 })
 ```
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -315,6 +315,7 @@ export function mount(
     ...options?.attrs,
     ...options?.propsData,
     ...options?.props,
+    ...options?.vModel,
     ref: MOUNT_COMPONENT_REF
   })
 
@@ -342,7 +343,7 @@ export function mount(
 
   // add tracking for emitted events
   // this must be done after `createApp`: https://github.com/vuejs/vue-test-utils-next/issues/436
-  attachEmitListener()
+  attachEmitListener((options?.vModel && Object.keys(options.vModel)) ?? [])
 
   // global mocks mixin
   if (global?.mocks) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,14 @@ export interface MountingOptions<Props, Data = {}> {
    */
   props?: (RawProps & Props) | ({} extends Props ? null : never)
   /**
-   * @deprecated use `data` instead.
+   * @deprecated use `props` instead.
    */
   propsData?: Props
+  /**
+   * Sets props to be updated with v-model `update` syntax sugar.
+   * @see https://next.vue-test-utils.vuejs.org/api/#vModel
+   */
+  vModel?: Props
   /**
    * Sets component attributes when mounted.
    * @see https://next.vue-test-utils.vuejs.org/api/#attrs

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -65,7 +65,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
       if (emits.includes(eventName)) continue
 
       element.addEventListener(eventName, (...args) => {
-        recordEvent(vm.$, eventName, args)
+        recordEvent(vm.$, eventName, args, [])
       })
     }
   }

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -55,6 +55,31 @@ expectError(
   })
 )
 
+const AppWithVModel = defineComponent({
+  props: {
+    a: {
+      type: String,
+      required: true
+    },
+    b: Number
+  },
+  template: ''
+})
+
+// accept props - vm is properly typed
+expectType<string>(
+  mount(AppWithVModel, {
+    vModel: { a: 'Hello', b: 2 }
+  }).vm.a
+)
+
+// accept props - vm is properly typed
+expectType<number>(
+  mount(AppWithVModel, {
+    vModel: { a: 'Hello', b: 2 }
+  }).vm.b
+)
+
 const AppWithProps = {
   props: {
     a: {

--- a/tests/mountingOptions/vModel.spec.ts
+++ b/tests/mountingOptions/vModel.spec.ts
@@ -12,7 +12,7 @@ describe('vModel', () => {
         {{ foo }}
       `,
       methods: {
-      handle($event: KeyboardEvent) {
+        handle($event: KeyboardEvent) {
           this.$emit('update:foo', ($event.target as HTMLInputElement).value)
         }
       }
@@ -30,4 +30,3 @@ describe('vModel', () => {
     expect(wrapper.html()).toContain('bar')
   })
 })
-

--- a/tests/mountingOptions/vModel.spec.ts
+++ b/tests/mountingOptions/vModel.spec.ts
@@ -1,0 +1,33 @@
+import { mount } from '../../src'
+import WithProps from './components/WithProps.vue'
+import Hello from './components/Hello.vue'
+import { defineComponent, h } from 'vue'
+
+describe('vModel', () => {
+  it('updates v-model automatically', async () => {
+    const Comp = defineComponent({
+      props: ['foo'],
+      template: `
+        <input @input="handle" />
+        {{ foo }}
+      `,
+      methods: {
+      handle($event: KeyboardEvent) {
+          this.$emit('update:foo', ($event.target as HTMLInputElement).value)
+        }
+      }
+    })
+
+    const wrapper = mount(Comp, {
+      vModel: {
+        foo: 'foo'
+      }
+    })
+
+    expect(wrapper.html()).toContain('foo')
+    wrapper.find('input').element.value = 'bar'
+    await wrapper.find('input').trigger('input')
+    expect(wrapper.html()).toContain('bar')
+  })
+})
+


### PR DESCRIPTION
Add a `vModel` mounting option.

I'd like lots of feedback. Please scrutinize - once we add this feature, we cannot go back or make any changes. We will need to maintain this for years to come. I am sure I am missing some tests and edge cases.

Also would like the opinion of @nekosaur and @kaelWD and @nandi95 - you are heavy users of test utils and have provided lots of useful feedback and contributions. Does this help with your `vModel` needs?

Component:
```vue
<template>
  <input @input="updateValue" />
  {{ color }}
</template>

<script>
export default {
  props: {
    color: String
  },
  methods: {
    handle($event) {
      this.$emit('update:color', $event.target.value)
    }
  }
}
</script>
```

Test:

```js
it('updates v-model automatically', async () => {
  const wrapper = mount(Component, {
    vModel: {
      color: 'red'
    }
  })

  expect(wrapper.html()).toContain('red')

  // update the input value
  wrapper.find('input').element.value = 'blue'
  // trigger the input event
  await wrapper.find('input').trigger('input')

  // value is updated and reflected in the DOM
  expect(wrapper.html()).toContain('blue')
})
```

resolves #https://github.com/vuejs/vue-test-utils-next/issues/321 and https://github.com/vuejs/vue-test-utils-next/discussions/279.
