### PR TITLE
feat: `vmodel` helper for two way binding

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -4,6 +4,7 @@ import {
   ComponentPublicInstance,
   ComponentInternalInstance
 } from 'vue'
+import { VModel } from './vmodel'
 
 type Events<T = unknown> = Record<number, Record<string, T[]>>
 
@@ -27,20 +28,23 @@ export function emitted<T = unknown>(
   return vmEvents
 }
 
-export const attachEmitListener = () => {
+export const attachEmitListener = (vmodels: Map<string, VModel<any>>) => {
   events = {}
   // use devtools to capture this "emit"
-  setDevtoolsHook(createDevTools(events))
+  setDevtoolsHook(createDevTools(events, vmodels))
 }
 
 // devtools hook only catches Vue component custom events
-function createDevTools(events: Events): any {
+function createDevTools(
+  events: Events,
+  vmodels: Map<string, VModel<any>>
+): any {
   return {
     emit(eventType, ...payload) {
       if (eventType !== DevtoolsHooks.COMPONENT_EMIT) return
 
       const [rootVM, componentVM, event, eventArgs] = payload
-      recordEvent(componentVM, event, eventArgs)
+      recordEvent(componentVM, event, eventArgs, vmodels)
     }
   } as Partial<typeof devtools>
 }
@@ -48,7 +52,8 @@ function createDevTools(events: Events): any {
 export const recordEvent = (
   vm: ComponentInternalInstance,
   event: string,
-  args: unknown[]
+  args: unknown[],
+  vmodels?: Map<string, VModel<any>>
 ): void => {
   // Functional component wrapper creates a parent component
   let wrapperVm = vm
@@ -60,6 +65,26 @@ export const recordEvent = (
   }
   if (!(event in events[cid])) {
     events[cid][event] = []
+  }
+
+  // update vmodel
+  if (event.startsWith('update:')) {
+    const prop = event.slice(7)
+    const vmodel = vmodels?.get(prop)
+    if (vmodel) {
+      if (args.length !== 1) {
+        throw new Error(
+          'Two-way bound properties have to emit a single value. ' +
+            args.length +
+            ' values given.'
+        )
+      }
+      const v = args[0]
+      vmodel.value.value = v
+      vmodel.onChange?.(v)
+    } else {
+      // should we warn here?
+    }
   }
 
   // Record the event message sent by the emit

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
 import { config } from './config'
 import { flushPromises } from './utils/flushPromises'
+import { vmodel } from './vmodel'
 
 export {
   mount,
@@ -14,5 +15,6 @@ export {
   DOMWrapper,
   config,
   flushPromises,
-  MountingOptions
+  MountingOptions,
+  vmodel
 }

--- a/src/vmodel.ts
+++ b/src/vmodel.ts
@@ -1,0 +1,23 @@
+import { Ref, ref, UnwrapRef } from 'vue'
+
+export interface VModel<T> {
+  value: Ref<UnwrapRef<T>>
+  onChange?(v: T): void
+}
+
+const vmodels = new Set<any>()
+
+export function isVModel(v: any) {
+  return vmodels.has(v)
+}
+
+export function vmodel<T>(v: T, onChange?: (d: T) => {}): VModel<T> {
+  const m = {
+    value: ref(v),
+    onChange
+  }
+
+  vmodels.add(m)
+
+  return m
+}

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '../src'
+import { mount, vmodel } from '../src'
 import WithProps from './components/WithProps.vue'
 import Hello from './components/Hello.vue'
 import { defineComponent, h } from 'vue'
@@ -101,11 +101,12 @@ describe('props', () => {
       }
     })
 
+    // @ts-expect-error TODO fix the type
     const wrapper = mount(component, {
       props: {
-        modelValue: 1,
-        'onUpdate:modelValue': async (modelValue: number) =>
-          wrapper.setProps({ modelValue })
+        modelValue: vmodel(1)
+        // 'onUpdate:modelValue': async (modelValue: number) =>
+        //   wrapper.setProps({ modelValue })
       }
     })
 


### PR DESCRIPTION
Proposal for having a `vmodel` function to explicitly wrap `vmodel` value - @nekosaur, @KaelWD, @nandi95 and @cexbrayat 


```ts
const wrapper = mount(component, {
  props: {
    modelValue: vmodel(1, jest.fn()) // now modelValue will be reactive
  }
})
```
## vmodel

`vmodel` is a new function which will return a new `vmodel` object

```ts
export interface VModel<T> {
  value: Ref<UnwrapRef<T>>
  onChange?(v: T): void
}
```


Test:
```ts
  it('should return the updated props on 2 way binding', async () => {
    const component = defineComponent({
      template: '<button @click="increment"></button>',
      props: {
        modelValue: {
          type: Number,
          required: true
        }
      },
      emits: ['update:modelValue'],
      setup(props, ctx) {
        return {
          increment: () => ctx.emit('update:modelValue', props.modelValue + 1)
        }
      }
    })

    // @ts-expect-error TODO fix the type
    const wrapper = mount(component, {
      props: {
        modelValue: vmodel(1)
        // Not needed 
        // 'onUpdate:modelValue': async (modelValue: number) =>
        //   wrapper.setProps({ modelValue })
      }
    })

    expect(wrapper.props('modelValue')).toBe(1)
    await wrapper.trigger('click')
    expect(wrapper.props('modelValue')).toBe(2)
  })
``` 


### Other options

Implementation with a new `vmodel` option : https://github.com/vuejs/vue-test-utils-next/pull/525 

### Note

Types are not working with this, is this API is accepted I can fix that.