### PR TITLE
fix: emits can be an object

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -56,7 +56,15 @@ export class VueWrapper<T extends ComponentPublicInstance>
     const vm = this.vm
     if (!vm) return
 
-    const emits = vm.$options.emits || []
+    const emits = vm.$options.emits
+      ? // if emits is declared as an array
+        Array.isArray(vm.$options.emits)
+        ? // use it
+          vm.$options.emits
+        : // otherwise it's declared as an object
+          // and we only need the keys
+          Object.keys(vm.$options.emits)
+      : []
     const element = this.element
     for (let eventName of Object.keys(eventTypes)) {
       // if a component includes events in 'emits' with the same name as native

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -137,7 +137,9 @@ describe('emitted', () => {
   it('should not propagate child custom events', () => {
     const Child = defineComponent({
       name: 'Child',
-      emits: ['hi'],
+      emits: {
+        hi: (foo: 'foo', bar: 'bar') => true
+      },
       setup(props, { emit }) {
         return () =>
           h('div', [h('button', { onClick: () => emit('hi', 'foo', 'bar') })])


### PR DESCRIPTION
The fix introduced in #521 only accounts for emits define as an array, but it can also be define as an object.
The latest rc.5 release breaks on components that use an object to define emits with:

    TypeError: emits.includes is not a function

This commit fixes the unit test to have both cases check, and the relevant code to properly handle the object case.