### PR TITLE
refactor: app config in test

### DIFF
--- a/tests/features/async-components.spec.ts
+++ b/tests/features/async-components.spec.ts
@@ -1,11 +1,7 @@
 import { defineAsyncComponent, defineComponent, h, AppConfig } from 'vue'
 import { mount, flushPromises } from '../../src'
 
-const config: AppConfig = {
-  optionMergeStrategies: {},
-  globalProperties: {},
-  isCustomElement: (tag: string) => false,
-  performance: false,
+const config: Partial<AppConfig> = {
   errorHandler: (error: unknown) => {
     if ((error as Error).message.match(/Async component failed to load./)) {
       return


### PR DESCRIPTION
The test does not need to declare a full configuration.
This will break compilation with Vue v3.1 as a new `compilerOptions` has been added to `AppConfig`.
Refactoring the config to be a partial one is more accurate and awill allow us to upgrade to v3.1 when it's out.