### PR TITLE
docs: fix dead links

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -316,7 +316,7 @@ type GlobalMountOptions = {
 }
 ```
 
-You can configure all the `global` options on both a per test basis and globally for all tests. [See here for how to configure project wide defaults](/api/#global-config-2).
+You can configure all the `global` options on both a per test basis and globally for all tests. [See here for how to configure project wide defaults](#global-config).
 
 #### global.components
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -42,7 +42,7 @@ In Vue 2, it was common for plugins to mutate the global Vue instance and attach
 
 To avoid polluting the global Vue instance in Vue Test Utils v1, we provided a `createLocalVue` function and `localVue` mounting option. This would let you have an isolated Vue instance for each test, avoiding cross test contamination. This is no longer an issue in Vue 3, since plugins, mixins etc do not mutate the global Vue instance.
 
-For most cases where you would previously use `createLocalVue` and the `localVue` mounting option to install a plugin, mixin or directive, you now use the [`global` mounting option](/v2/api/#global-components). Here is an example of a component and test that used `localVue`, and how it now looks (using `global.plugins`, since Vuex is a plugin):
+For most cases where you would previously use `createLocalVue` and the `localVue` mounting option to install a plugin, mixin or directive, you now use the [`global` mounting option](/api/#global-components). Here is an example of a component and test that used `localVue`, and how it now looks (using `global.plugins`, since Vuex is a plugin):
 
 **Before**:
 


### PR DESCRIPTION
Should fix the CI builds again (Netlify was failing because of dead links in docs).