### PR TITLE
fix: shallow config issue

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { GlobalMountOptions } from './types'
 import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
 
-interface GlobalConfigOptions {
+export interface GlobalConfigOptions {
   global: Required<GlobalMountOptions>
   plugins: {
     VueWrapper: Pluggable<VueWrapper<ComponentPublicInstance>>

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -319,8 +319,7 @@ export function mount(
     ...options?.props,
     ref: MOUNT_COMPONENT_REF
   })
-
-  const global = mergeGlobalProperties(config.global, options?.global)
+  const global = mergeGlobalProperties(options?.global)
   component.components = { ...component.components, ...global.components }
 
   // create the wrapper component
@@ -426,7 +425,7 @@ export function mount(
   if (global?.stubs) {
     for (const [name, stub] of Object.entries(global.stubs)) {
       if (stub === true) {
-        const stubbed = createStub({ name, props: {} })
+        const stubbed = createStub({ name, props: {}, renderStubDefaultSlot: global?.renderStubDefaultSlot })
         // default stub.
         app.component(name, stubbed)
       } else {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -413,8 +413,7 @@ export function mount(
   // even if we are using `mount`, we will still
   // stub out Transition and Transition Group by default.
   stubComponents(
-    global.stubs,
-    global.renderStubDefaultSlot ? false : options?.shallow
+    global.stubs, options?.shallow, global?.renderStubDefaultSlot
   )
 
   // users expect stubs to work with globally registered

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -411,9 +411,7 @@ export function mount(
   // stubs
   // even if we are using `mount`, we will still
   // stub out Transition and Transition Group by default.
-  stubComponents(
-    global.stubs, options?.shallow, global?.renderStubDefaultSlot
-  )
+  stubComponents(global.stubs, options?.shallow, global?.renderStubDefaultSlot)
 
   // users expect stubs to work with globally registered
   // components, too, such as <router-link> and <router-view>
@@ -425,7 +423,11 @@ export function mount(
   if (global?.stubs) {
     for (const [name, stub] of Object.entries(global.stubs)) {
       if (stub === true) {
-        const stubbed = createStub({ name, props: {}, renderStubDefaultSlot: global?.renderStubDefaultSlot })
+        const stubbed = createStub({
+          name,
+          props: {},
+          renderStubDefaultSlot: global?.renderStubDefaultSlot
+        })
         // default stub.
         app.component(name, stubbed)
       } else {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -12,7 +12,6 @@ import {
 } from 'vue'
 import { hyphenate } from './utils/vueShared'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
-import { config } from './config'
 import { matchName } from './utils/matchName'
 import { ComponentInternalInstance } from '@vue/runtime-core'
 
@@ -33,7 +32,7 @@ export const createStub = ({
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 
   const render = (ctx: ComponentPublicInstance) => {
-    return h(tag, props, (renderStubDefaultSlot || config.renderStubDefaultSlot) ? ctx.$slots : undefined)
+    return h(tag, props, renderStubDefaultSlot ? ctx.$slots : undefined)
   }
 
   return defineComponent({
@@ -160,7 +159,7 @@ export function stubComponents(
 
       // No name found?
       if (!registeredName && !componentName) {
-        return shallow ? ['stub'] : args
+        return (renderStubDefaultSlot || !shallow) ? args : ['stub']
       }
 
       let stub = null

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -20,22 +20,20 @@ interface StubOptions {
   name: string
   props?: any
   propsDeclaration?: any
-}
-
-function getSlots(ctx: ComponentPublicInstance): Slots | undefined {
-  return !config.renderStubDefaultSlot ? undefined : ctx.$slots
+  renderStubDefaultSlot?: boolean
 }
 
 export const createStub = ({
   name,
   props,
-  propsDeclaration
+  propsDeclaration,
+  renderStubDefaultSlot,
 }: StubOptions): ComponentOptions => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 
   const render = (ctx: ComponentPublicInstance) => {
-    return h(tag, props, getSlots(ctx))
+    return h(tag, props, (renderStubDefaultSlot || config.renderStubDefaultSlot) ? ctx.$slots : undefined)
   }
 
   return defineComponent({
@@ -112,7 +110,8 @@ const isFunctionalComponent = (type: VNodeTypes): type is ComponentOptions =>
 
 export function stubComponents(
   stubs: Record<any, any> = {},
-  shallow: boolean = false
+  shallow: boolean = false,
+  renderStubDefaultSlot: boolean = false
 ) {
   transformVNodeArgs((args, instance: ComponentInternalInstance | null) => {
     const [nodeType, props, children, patchFlag, dynamicProps] = args
@@ -199,7 +198,7 @@ export function stubComponents(
         }
 
         const propsDeclaration = type?.props || {}
-        const newStub = createStub({ name, propsDeclaration, props })
+        const newStub = createStub({ name, propsDeclaration, props, renderStubDefaultSlot })
         stubs[name] = newStub
         return [newStub, props, children, patchFlag, dynamicProps]
       }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -26,7 +26,7 @@ export const createStub = ({
   name,
   props,
   propsDeclaration,
-  renderStubDefaultSlot,
+  renderStubDefaultSlot
 }: StubOptions): ComponentOptions => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
@@ -159,7 +159,7 @@ export function stubComponents(
 
       // No name found?
       if (!registeredName && !componentName) {
-        return (renderStubDefaultSlot || !shallow) ? args : ['stub']
+        return renderStubDefaultSlot || !shallow ? args : ['stub']
       }
 
       let stub = null
@@ -197,7 +197,12 @@ export function stubComponents(
         }
 
         const propsDeclaration = type?.props || {}
-        const newStub = createStub({ name, propsDeclaration, props, renderStubDefaultSlot })
+        const newStub = createStub({
+          name,
+          propsDeclaration,
+          props,
+          renderStubDefaultSlot
+        })
         stubs[name] = newStub
         return [newStub, props, children, patchFlag, dynamicProps]
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { GlobalMountOptions } from './types'
 import { AppConfig } from 'vue'
+import {config} from "./config";
 
 function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
   if (source.stubs) {
@@ -14,13 +15,14 @@ function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
 }
 
 export function mergeGlobalProperties(
-  configGlobal: GlobalMountOptions = {},
   mountGlobal: GlobalMountOptions = {}
 ): Required<GlobalMountOptions> {
   const stubs: Record<string, any> = {}
-
+  const configGlobal: GlobalMountOptions = config?.global ?? {}
   mergeStubs(stubs, configGlobal)
   mergeStubs(stubs, mountGlobal)
+
+  const renderStubDefaultSlot = mountGlobal.renderStubDefaultSlot ?? config?.renderStubDefaultSlot ?? configGlobal?.renderStubDefaultSlot
 
   return {
     mixins: [...(configGlobal.mixins || []), ...(mountGlobal.mixins || [])],
@@ -31,9 +33,7 @@ export function mergeGlobalProperties(
     mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
     config: { ...configGlobal.config, ...mountGlobal.config },
     directives: { ...configGlobal.directives, ...mountGlobal.directives },
-    renderStubDefaultSlot: !!(mountGlobal.renderStubDefaultSlot !== undefined
-      ? mountGlobal.renderStubDefaultSlot
-      : configGlobal.renderStubDefaultSlot)
+    renderStubDefaultSlot
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { GlobalMountOptions } from './types'
 import { AppConfig } from 'vue'
-import {config} from "./config";
+import { config } from './config'
 
 function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
   if (source.stubs) {
@@ -22,7 +22,10 @@ export function mergeGlobalProperties(
   mergeStubs(stubs, configGlobal)
   mergeStubs(stubs, mountGlobal)
 
-  const renderStubDefaultSlot = mountGlobal.renderStubDefaultSlot ?? config?.renderStubDefaultSlot ?? configGlobal?.renderStubDefaultSlot
+  const renderStubDefaultSlot =
+    mountGlobal.renderStubDefaultSlot ??
+    config?.renderStubDefaultSlot ??
+    configGlobal?.renderStubDefaultSlot
 
   return {
     mixins: [...(configGlobal.mixins || []), ...(mountGlobal.mixins || [])],

--- a/tests/mountingOptions/global.components.spec.ts
+++ b/tests/mountingOptions/global.components.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from '../../src'
+import {defineComponent} from "vue";
 
 describe('global.components', () => {
   it('registers a component to all components', () => {
@@ -69,5 +70,30 @@ describe('global.components', () => {
     expect(spy).not.toHaveBeenCalled()
     spy.mockRestore()
     expect(wrapper.text()).toBe('Global')
+  })
+  it('shallow with renderStubDefaultSlot', () => {
+    const Child = defineComponent({
+      template: '<div><p>child</p><slot /></div>'
+    })
+    const Component = defineComponent({
+      template: '<div><Child><div>hello</div></Child></div>',
+      components: {
+        Child
+      },
+    })
+    const wrapper = mount(Component, {
+      shallow: true,
+      global: {
+        renderStubDefaultSlot: true
+      }
+    })
+
+    expect(wrapper.html()).toEqual(
+       '<div>\n' +
+                '  <child-stub>\n' +
+                '    <div>hello</div>\n' +
+                '  </child-stub>\n' +
+                '</div>'
+  )
   })
 })

--- a/tests/mountingOptions/global.components.spec.ts
+++ b/tests/mountingOptions/global.components.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '../../src'
-import {defineComponent} from "vue";
+import { defineComponent } from 'vue'
 
 describe('global.components', () => {
   it('registers a component to all components', () => {
@@ -79,7 +79,7 @@ describe('global.components', () => {
       template: '<div><Child><div>hello</div></Child></div>',
       components: {
         Child
-      },
+      }
     })
     const wrapper = mount(Component, {
       shallow: true,
@@ -89,11 +89,11 @@ describe('global.components', () => {
     })
 
     expect(wrapper.html()).toEqual(
-       '<div>\n' +
-                '  <child-stub>\n' +
-                '    <div>hello</div>\n' +
-                '  </child-stub>\n' +
-                '</div>'
+      '<div>\n' +
+        '  <child-stub>\n' +
+        '    <div>hello</div>\n' +
+        '  </child-stub>\n' +
+        '</div>'
     )
   })
 })

--- a/tests/mountingOptions/global.components.spec.ts
+++ b/tests/mountingOptions/global.components.spec.ts
@@ -71,7 +71,7 @@ describe('global.components', () => {
     spy.mockRestore()
     expect(wrapper.text()).toBe('Global')
   })
-  it('shallow with renderStubDefaultSlot', () => {
+  it('render children with shallow and renderStubDefaultSlot', () => {
     const Child = defineComponent({
       template: '<div><p>child</p><slot /></div>'
     })
@@ -94,6 +94,6 @@ describe('global.components', () => {
                 '    <div>hello</div>\n' +
                 '  </child-stub>\n' +
                 '</div>'
-  )
+    )
   })
 })

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -607,7 +607,7 @@ describe('mounting options: stubs', () => {
       )
     })
 
-    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', () => {
+    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', async() => {
       config.renderStubDefaultSlot = true
 
       const SimpleSlot = {

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -607,7 +607,7 @@ describe('mounting options: stubs', () => {
       )
     })
 
-    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', async () => {
+    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', () => {
       config.renderStubDefaultSlot = true
 
       const SimpleSlot = {

--- a/tests/mountingOptions/stubs.global.spec.ts
+++ b/tests/mountingOptions/stubs.global.spec.ts
@@ -607,7 +607,7 @@ describe('mounting options: stubs', () => {
       )
     })
 
-    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', async() => {
+    it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', async () => {
       config.renderStubDefaultSlot = true
 
       const SimpleSlot = {


### PR DESCRIPTION
## What for ??
I'm sorry to bother you guys 🙇🏻 
This pull request is for #606 

## Why the issue happened.
This caused that issue.

```js
stubComponents(global.stubs, global.renderStubDefaultSlot ? false : options?.shallow )
```

If global.renderStubDefaultSlot is true, options.shallow is ignored.
Hence, the issue caused.