### PR TITLE
featureRequest: add isVisible to VueWrapper

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -131,10 +131,6 @@ export class VueWrapper<T extends ComponentPublicInstance>
 
     return createWrapperError('DOMWrapper')
   }
-  isVisible(): boolean {
-    const domWrapper = new DOMWrapper(this.element)
-    return domWrapper.isVisible()
-  }
 
   get<K extends keyof HTMLElementTagNameMap>(
     selector: K
@@ -230,6 +226,11 @@ export class VueWrapper<T extends ComponentPublicInstance>
       : this.element.querySelectorAll(selector)
 
     return Array.from(results).map((element) => new DOMWrapper(element))
+  }
+
+  isVisible(): boolean {
+    const domWrapper = new DOMWrapper(this.element)
+    return domWrapper.isVisible()
   }
 
   setData(data: Record<string, any>): Promise<void> {

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -131,6 +131,10 @@ export class VueWrapper<T extends ComponentPublicInstance>
 
     return createWrapperError('DOMWrapper')
   }
+  isVisible(): boolean {
+    const domWrapper = new DOMWrapper(this.element)
+    return domWrapper.isVisible()
+  }
 
   get<K extends keyof HTMLElementTagNameMap>(
     selector: K

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -188,5 +188,27 @@ describe('isVisible', () => {
         expect(show.isVisible()).toBe(true)
       })
     })
+    describe('child has two nodes', () => {
+      const Foo = defineComponent({
+        template: `<div />
+                     <span />`
+      })
+      const Root = defineComponent({
+        template: '<Foo v-show="false" />',
+        components: {
+          Foo
+        }
+      })
+      it('mount: returns false', () => {
+        const wrapper = mount(Root)
+        expect(wrapper.isVisible()).toBe(false)
+      })
+      it('shallowMount: return false', () => {
+        const wrapper = mount(Root, {
+          shallow: true
+        })
+        expect(wrapper.isVisible()).toBe(false)
+      })
+    })
   })
 })

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -165,7 +165,7 @@ describe('isVisible', () => {
         template: '<div>show</div>'
       })
       const Root = defineComponent({
-        template: '<div><HiddenInner/><ShowInner /></div>',
+        template: '<div><Hidden /><Show /></div>',
         components: {
           Hidden,
           Show

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -130,9 +130,11 @@ describe('isVisible', () => {
       const Hidden = defineComponent({
         template: '<div>hidden</div>'
       })
+
       const Show = defineComponent({
         template: '<div>show</div>'
       })
+
       const Root = defineComponent({
         template: '<div><Hidden v-show="false" /><Show /></div>',
         components: {
@@ -140,14 +142,16 @@ describe('isVisible', () => {
           Show
         }
       })
-      it('mount:returns false when root has v-show=false', () => {
+
+      it('mount: returns false when root has v-show=false', () => {
         const wrapper = mount(Root)
         const hidden = wrapper.findComponent(Hidden)
         const show = wrapper.findComponent(Show)
         expect(hidden.isVisible()).toBe(false)
         expect(show.isVisible()).toBe(true)
       })
-      it('shallowMount:returns false when root has v-show=false', () => {
+
+      it('shallowMount: returns false when root has v-show=false', () => {
         const wrapper = mount(Root, {
           shallow: true
         })
@@ -157,13 +161,16 @@ describe('isVisible', () => {
         expect(show.isVisible()).toBe(true)
       })
     })
+
     describe('child component has v-show', () => {
       const Hidden = defineComponent({
         template: '<div v-show="false">hidden</div>'
       })
+
       const Show = defineComponent({
         template: '<div>show</div>'
       })
+
       const Root = defineComponent({
         template: '<div><Hidden /><Show /></div>',
         components: {
@@ -171,13 +178,15 @@ describe('isVisible', () => {
           Show
         }
       })
-      it('mount:returns false when child has v-show=false', () => {
+
+      it('mount: returns false when child has v-show=false', () => {
         const wrapper = mount(Root)
         const hidden = wrapper.findComponent(Hidden)
         const show = wrapper.findComponent(Show)
         expect(hidden.isVisible()).toBe(false)
         expect(show.isVisible()).toBe(true)
       })
+
       it('shallowMount: returns true when child has v-show=false, because of shallow mount', () => {
         const wrapper = mount(Root, {
           shallow: true
@@ -188,21 +197,24 @@ describe('isVisible', () => {
         expect(show.isVisible()).toBe(true)
       })
     })
+
     describe('child has two nodes', () => {
       const Foo = defineComponent({
-        template: `<div />
-                     <span />`
+        template: `<div /><span />`
       })
+
       const Root = defineComponent({
         template: '<Foo v-show="false" />',
         components: {
           Foo
         }
       })
+
       it('mount: returns false', () => {
         const wrapper = mount(Root)
         expect(wrapper.isVisible()).toBe(false)
       })
+
       it('shallowMount: return false', () => {
         const wrapper = mount(Root, {
           shallow: true

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -128,7 +128,7 @@ describe('isVisible', () => {
   describe('isVisible with find Component', () => {
     describe('root component has v-show', () => {
       const Hidden = defineComponent({
-        template: '<div>hidden</div>',
+        template: '<div>hidden</div>'
       })
       const Show = defineComponent({
         template: '<div>show</div>'
@@ -137,7 +137,7 @@ describe('isVisible', () => {
         template: '<div><Hidden v-show="false" /><Show /></div>',
         components: {
           Hidden,
-          Show,
+          Show
         }
       })
       it('mount:returns false when root has v-show=false', () => {
@@ -149,7 +149,7 @@ describe('isVisible', () => {
       })
       it('shallowMount:returns false when root has v-show=false', () => {
         const wrapper = mount(Root, {
-          shallow: true,
+          shallow: true
         })
         const hidden = wrapper.findComponent(Hidden)
         const show = wrapper.findComponent(Show)
@@ -180,7 +180,7 @@ describe('isVisible', () => {
       })
       it('shallowMount: returns true when child has v-show=false, because of shallow mount', () => {
         const wrapper = mount(Root, {
-          shallow: true,
+          shallow: true
         })
         const hidden = wrapper.findComponent(Hidden)
         const show = wrapper.findComponent(Show)

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -124,4 +124,69 @@ describe('isVisible', () => {
 
     document.head.removeChild(style)
   })
+
+  describe('isVisible with find Component', () => {
+    describe('root component has v-show', () => {
+      const Hidden = defineComponent({
+        template: '<div>hidden</div>',
+      })
+      const Show = defineComponent({
+        template: '<div>show</div>'
+      })
+      const Root = defineComponent({
+        template: '<div><Hidden v-show="false" /><Show /></div>',
+        components: {
+          Hidden,
+          Show,
+        }
+      })
+      it('mount:returns false when root has v-show=false', () => {
+        const wrapper = mount(Root)
+        const hidden = wrapper.findComponent(Hidden)
+        const show = wrapper.findComponent(Show)
+        expect(hidden.isVisible()).toBe(false)
+        expect(show.isVisible()).toBe(true)
+      })
+      it('shallowMount:returns false when root has v-show=false', () => {
+        const wrapper = mount(Root, {
+          shallow: true,
+        })
+        const hidden = wrapper.findComponent(Hidden)
+        const show = wrapper.findComponent(Show)
+        expect(hidden.isVisible()).toBe(false)
+        expect(show.isVisible()).toBe(true)
+      })
+    })
+    describe('child component has v-show', () => {
+      const Hidden = defineComponent({
+        template: '<div v-show="false">hidden</div>'
+      })
+      const Show = defineComponent({
+        template: '<div>show</div>'
+      })
+      const Root = defineComponent({
+        template: '<div><HiddenInner/><ShowInner /></div>',
+        components: {
+          Hidden,
+          Show
+        }
+      })
+      it('mount:returns false when child has v-show=false', () => {
+        const wrapper = mount(Root)
+        const hidden = wrapper.findComponent(Hidden)
+        const show = wrapper.findComponent(Show)
+        expect(hidden.isVisible()).toBe(false)
+        expect(show.isVisible()).toBe(true)
+      })
+      it('shallowMount: returns true when child has v-show=false, because of shallow mount', () => {
+        const wrapper = mount(Root, {
+          shallow: true,
+        })
+        const hidden = wrapper.findComponent(Hidden)
+        const show = wrapper.findComponent(Show)
+        expect(hidden.isVisible()).toBe(true)
+        expect(show.isVisible()).toBe(true)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## What I want
I'd like to use isVisible in vueWrapper.
I think findComponent and isVisible interfaces are very useful for test, but actually findComponent returns vueWrapper instance which doesn't have isVisible interface.
Hence, below code doesn't work well...

```vue
const Comp = defineComponent({
  template: '<div />'
})
const Root = defineComponent({
  template: '<div><Child v-show=true /></div>',
  component: {
     Comp,
 })

const wrapper = mount(Root)
console.log(wrapper.findComponent(Comp).isVisible()); // isVisible is not a function
```

What do you think this featureRequest ....???

I'm sorry if I'm against policy of design, but I guess this specification is more useful than current.