### PR TITLE
fix: better errors for async find

### DIFF
--- a/src/errorWrapper.ts
+++ b/src/errorWrapper.ts
@@ -4,6 +4,10 @@ export function createWrapperError<T extends object>(
   return new Proxy<T>(Object.create(null), {
     get(obj, prop) {
       switch (prop) {
+        case 'then':
+          // allows for better errors when wrapping `find` in `await`
+          // https://github.com/vuejs/vue-test-utils-next/issues/638
+          return
         case 'exists':
           return () => false
         default:

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -1,6 +1,6 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 
-import { mount } from '../src'
+import { mount, VueWrapper } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
 
 describe('find', () => {
@@ -79,6 +79,25 @@ describe('find', () => {
 
     expect(wrapper.html()).toContain('Fallback content')
     expect(wrapper.find('div').exists()).toBeTruthy()
+  })
+
+  test('can wrap `find` in an async function', async () => {
+    async function findAfterNextTick(
+      wrapper: VueWrapper<any>,
+      selector: string
+    ) {
+      await nextTick()
+      return wrapper.find(selector)
+    }
+
+    const wrapper = mount({
+      template: `<div>My component</div>`
+    })
+    const foundElement = await findAfterNextTick(
+      wrapper,
+      '.something-that-does-not-exist'
+    )
+    expect(foundElement.exists()).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
resolves https://github.com/vuejs/vue-test-utils-next/issues/638

Eh, a bit "smart" but avoids having to duplicate [everything like in Test Utils v1](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/error-wrapper.js), which over the years has become tough to maintain.