### PR TITLE
fix: Gracefully handle empty root node for nested component

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -123,7 +123,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
     const result = this.parentElement['__vue_app__']
       ? // force using the parentElement to allow finding the root element
         this.parentElement.querySelector(selector)
-      : this.element.querySelector(selector)
+      : this.element.querySelector && this.element.querySelector(selector)
 
     if (result) {
       return new DOMWrapper(result)
@@ -223,7 +223,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
   findAll(selector: string): DOMWrapper<Element>[] {
     const results = this.parentElement['__vue_app__']
       ? this.parentElement.querySelectorAll(selector)
-      : this.element.querySelectorAll(selector)
+      : this.element.querySelectorAll ? this.element.querySelectorAll(selector) : []
 
     return Array.from(results).map((element) => new DOMWrapper(element))
   }

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -223,7 +223,9 @@ export class VueWrapper<T extends ComponentPublicInstance>
   findAll(selector: string): DOMWrapper<Element>[] {
     const results = this.parentElement['__vue_app__']
       ? this.parentElement.querySelectorAll(selector)
-      : this.element.querySelectorAll ? this.element.querySelectorAll(selector) : []
+      : this.element.querySelectorAll
+      ? this.element.querySelectorAll(selector)
+      : []
 
     return Array.from(results).map((element) => new DOMWrapper(element))
   }

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -225,7 +225,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
       ? this.parentElement.querySelectorAll(selector)
       : this.element.querySelectorAll
       ? this.element.querySelectorAll(selector)
-      : []
+      : ([] as unknown as NodeListOf<Element>)
 
     return Array.from(results).map((element) => new DOMWrapper(element))
   }

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -99,6 +99,22 @@ describe('find', () => {
     )
     expect(foundElement.exists()).toBeFalsy()
   })
+
+  test('handle empty root node', () => {
+    const EmptyTestComponent = {
+      name: 'EmptyTestComponent',
+      render: () => null
+    }
+    const Component = defineComponent({
+      render() {
+        return h('div', [h(EmptyTestComponent)])
+      }
+    })
+
+    const wrapper = mount(Component)
+    const etc = wrapper.findComponent({ name: 'EmptyTestComponent'})
+    expect(etc.find('p').exists()).toBe(false)
+  })
 })
 
 describe('findAll', () => {
@@ -177,5 +193,21 @@ describe('findAll', () => {
     const wrapper = mount(Foo)
 
     expect(wrapper.find('#foo').find('#bar').exists()).toBe(true)
+  })
+
+  test('handle empty/comment root node', () => {
+    const EmptyTestComponent = {
+      name: 'EmptyTestComponent',
+      render: () => null
+    }
+    const Component = defineComponent({
+      render() {
+        return h('div', [h(EmptyTestComponent)])
+      }
+    })
+
+    const wrapper = mount(Component)
+    const etc = wrapper.findComponent({ name: 'EmptyTestComponent'})
+    expect(etc.findAll('p')).toHaveLength(0)
   })
 })

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -112,7 +112,7 @@ describe('find', () => {
     })
 
     const wrapper = mount(Component)
-    const etc = wrapper.findComponent({ name: 'EmptyTestComponent'})
+    const etc = wrapper.findComponent({ name: 'EmptyTestComponent' })
     expect(etc.find('p').exists()).toBe(false)
   })
 })
@@ -207,7 +207,7 @@ describe('findAll', () => {
     })
 
     const wrapper = mount(Component)
-    const etc = wrapper.findComponent({ name: 'EmptyTestComponent'})
+    const etc = wrapper.findComponent({ name: 'EmptyTestComponent' })
     expect(etc.findAll('p')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
This PR covers a kind of edge case.

Conditions: 

1. The component to test is nested in an element (so the parent element is not the mount wrapper)
2. the component doesn't render anything (so `$el` is a comment node)
3. The component is extracted with `wrapper.findComponent(Component)`
4. The test tries to use `extractedWrapper.find()` or `ExtractedWrapper.findAll()`

This will fail with an error being thrown:
> `TypeError: this.element.querySelector(All) is not a function`

This PR handles this case in a graceful way.