### PR TITLE
fix: use `.mjs` extension for ESM bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/vue-test-utils.cjs.js",
   "unpkg": "dist/vue-test-utils.browser.js",
   "types": "dist/index.d.ts",
-  "module": "dist/vue-test-utils.esm-bundler.js",
+  "module": "dist/vue-test-utils.esm-bundler.mjs",
   "files": [
     "dist",
     "README.md",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ function createEntry(options) {
   if (format === 'es') {
     config.output.file = pkg.module
     if (isBrowser) {
-      config.output.file = 'dist/vue-test-utils.esm-browser.js'
+      config.output.file = 'dist/vue-test-utils.esm-browser.mjs'
     }
   }
   if (format === 'cjs') {


### PR DESCRIPTION
https://nodejs.org/api/packages.html#packages_determining_module_system

Without `type: "module"` in the `package.json`, Node.js (and therefore [Jest](https://github.com/facebook/jest/blob/v27.0.4/packages/jest-resolve/src/shouldLoadAsEsm.ts), too) treats these `.js` files as CommonJS modules, which is incorrect. It is also [causing trouble in `vite-jest`](https://github.com/sodatea/vite-jest/blob/4d3c7be1ab908a2dbf457d5830f357f5ff404db1/packages/vite-jest/vite-server.js#L8-L12).