### PR TITLE
workflow: add prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lint:fix": "yarn lint --write",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "vue-tsc": "vue-tsc --noEmit -p tsconfig.volar.json"
+    "vue-tsc": "vue-tsc --noEmit -p tsconfig.volar.json",
+    "prepublishOnly": "yarn build"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
To help avoid shipping unbuilt releases like rc.7 in the future.