### PR TITLE
fix: Allow finding component by definition when using shallow mount

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { GlobalMountOptions } from './types'
-import { AppConfig } from 'vue'
+import { ComponentOptions, VNodeTypes } from 'vue'
 import { config } from './config'
 
 function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
@@ -68,17 +68,19 @@ export const mergeDeep = (
   return target
 }
 
-export function isClassComponent(component: any) {
-  // TypeScript
-  return (
-    component.toString().includes('_super.apply(this, arguments) || this') ||
-    // native ES6
-    (typeof component === 'function' &&
-      /^\s*class\s+/.test(component.toString()))
-  )
+export function isClassComponent(component: VNodeTypes) {
+  return typeof component === 'function' && '__vccOpts' in component
 }
 
-export function isFunctionalComponent(component: any) {
+export function isComponent(
+  component: VNodeTypes
+): component is ComponentOptions {
+  return typeof component === 'object' || typeof component === 'function'
+}
+
+export function isFunctionalComponent(
+  component: VNodeTypes
+): component is ComponentOptions {
   return typeof component === 'function' && !isClassComponent(component)
 }
 

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -111,6 +111,17 @@ describe('findComponent', () => {
     expect(wrapper.findComponent(ComponentWithoutName).exists()).toBe(true)
   })
 
+  it('finds a component by its definition with shallow', () => {
+    const Component = {
+      template: '<div><other-name /></div>',
+      components: {
+        OtherName: Hello
+      }
+    }
+    const wrapper = mount(Component, { shallow: true })
+    expect(wrapper.findComponent(Hello).exists()).toBe(true)
+  })
+
   it('finds a component without a name by its locally assigned name', () => {
     const Component = {
       template: '<div><component-without-name/></div>',


### PR DESCRIPTION
ATM finding stubbed component is extremely inconsistent. It depends on "register name" in `components: {}` section, if component has `name` itself and so on, making it hard-to-guess if it will work and creating a regression,  compared to @vue/test-utils 1.x

This PR introduces a cache (using `WeakMap`, so we do not have to care about cleanup) and makes `matches` aware of stub