### PR TITLE
fix: do not stub slots content when using shallow mount

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -8,7 +8,8 @@ import {
   ComponentOptions,
   defineComponent,
   VNodeProps,
-  VNodeTypes
+  VNodeTypes,
+  ConcreteComponent
 } from 'vue'
 import { hyphenate } from './utils/vueShared'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
@@ -28,9 +29,9 @@ export const getOriginalVNodeTypeFromStub = (
   type: ComponentOptions
 ): VNodeTypes | undefined => stubsMap.get(type)
 
-const doNotStubComponents: WeakSet<ComponentOptions> = new WeakSet()
-const shouldNotStub = (type: ComponentOptions) => doNotStubComponents.has(type)
-export const addToDoNotStubComponents = (type: ComponentOptions) =>
+const doNotStubComponents: WeakSet<ConcreteComponent> = new WeakSet()
+const shouldNotStub = (type: ConcreteComponent) => doNotStubComponents.has(type)
+export const addToDoNotStubComponents = (type: ConcreteComponent) =>
   doNotStubComponents.add(type)
 
 export const createStub = ({

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -24,10 +24,14 @@ interface StubOptions {
 }
 
 const stubsMap: WeakMap<ComponentOptions, VNodeTypes> = new WeakMap()
-
 export const getOriginalVNodeTypeFromStub = (
   type: ComponentOptions
 ): VNodeTypes | undefined => stubsMap.get(type)
+
+const doNotStubComponents: WeakSet<ComponentOptions> = new WeakSet()
+const shouldNotStub = (type: ComponentOptions) => doNotStubComponents.has(type)
+export const addToDoNotStubComponents = (type: ComponentOptions) =>
+  doNotStubComponents.add(type)
 
 export const createStub = ({
   name,
@@ -155,6 +159,10 @@ export function stubComponents(
     }
 
     if (isComponent(type) || isFunctionalComponent(type)) {
+      if (shouldNotStub(type)) {
+        return args
+      }
+
       const registeredName = getComponentRegisteredName(instance, type)
       const componentName = type['name'] || type['displayName']
 

--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -1,6 +1,23 @@
 import { compile } from '@vue/compiler-dom'
 import * as vue from 'vue'
 import type { SetupContext } from 'vue'
+import { addToDoNotStubComponents } from '../stubs'
+
+const SlotWrapper = {
+  inheritAttrs: false,
+  setup(_: Record<string, any>, ctx: SetupContext) {
+    return () => {
+      const names = Object.keys(ctx.slots)
+      if (names.length === 0) {
+        return []
+      } else {
+        const slotName = names[0]
+        return ctx.slots[slotName]!(ctx.attrs)
+      }
+    }
+  }
+}
+addToDoNotStubComponents(SlotWrapper)
 
 export function processSlot(source = '', Vue = vue) {
   let template = source.trim()
@@ -23,24 +40,13 @@ export function processSlot(source = '', Vue = vue) {
     __BROWSER__ ? `'use strict';\n${code}` : code
   )
 
-  return {
+  const Component = {
     inheritAttrs: false,
     render: createRenderFunction(Vue),
     components: {
-      SlotWrapper: {
-        inheritAttrs: false,
-        setup(_: Record<string, any>, ctx: SetupContext) {
-          return () => {
-            const names = Object.keys(ctx.slots)
-            if (names.length === 0) {
-              return []
-            } else {
-              const slotName = names[0]
-              return ctx.slots[slotName]!(ctx.attrs)
-            }
-          }
-        }
-      }
+      SlotWrapper
     }
   }
+  addToDoNotStubComponents(Component)
+  return Component
 }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance, h, inject } from 'vue'
+import { defineComponent, ComponentPublicInstance, h, inject } from 'vue'
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
 import ComponentWithSlots from './components/ComponentWithSlots.vue'
@@ -67,11 +67,13 @@ describe('config', () => {
     })
 
     it('should evaluate given option as boolean', () => {
+      const Child = defineComponent({ template: '<div><slot></slot></div>' })
+      const Component = defineComponent({
+        components: { Child },
+        template: '<child><div id="default-slot" /></child>'
+      })
       // @ts-expect-error
-      let comp = mount(ComponentWithSlots, {
-        slots: {
-          default: '<div id="default-slot" />'
-        },
+      let comp = mount(Component, {
         shallow: true,
         global: {
           renderStubDefaultSlot: 'truthy'
@@ -81,10 +83,7 @@ describe('config', () => {
       expect(comp.find('#default-slot').exists()).toBe(true)
 
       // @ts-expect-error
-      let comp = mount(ComponentWithSlots, {
-        slots: {
-          default: '<div id="default-slot" />'
-        },
+      let comp = mount(Component, {
         shallow: true,
         global: {
           renderStubDefaultSlot: 0

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -84,6 +84,28 @@ describe('shallowMount', () => {
     expect(wrapper.find('.slot-content').exists()).toBe(true)
   })
 
+  it('correctly stubs components inside slot', () => {
+    const ComponentWithSlot = defineComponent({
+      template: '<div><slot></slot></div>'
+    })
+
+    const Foo = defineComponent({
+      name: 'Foo',
+      template: '<div class="unstubbed-foo">OK</div>'
+    })
+
+    const wrapper = shallowMount(ComponentWithSlot, {
+      global: {
+        components: { Foo }
+      },
+      slots: {
+        default: '<Foo />'
+      }
+    })
+
+    expect(wrapper.find('.unstubbed-foo').exists()).toBe(false)
+  })
+
   it('stubs all components, but allows providing custom stub', () => {
     const wrapper = mount(ComponentWithChildren, {
       shallow: true,

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -71,6 +71,19 @@ describe('shallowMount', () => {
     )
   })
 
+  it('correctly renders slot content', () => {
+    const ComponentWithSlot = defineComponent({
+      template: '<div><slot></slot></div>'
+    })
+
+    const wrapper = shallowMount(ComponentWithSlot, {
+      slots: {
+        default: '<span class="slot-content">test</span>'
+      }
+    })
+    expect(wrapper.find('.slot-content').exists()).toBe(true)
+  })
+
   it('stubs all components, but allows providing custom stub', () => {
     const wrapper = mount(ComponentWithChildren, {
       shallow: true,


### PR DESCRIPTION
Current implementation of `stubComponents` is extremely agressive and really stubs everything including wrappers created for slots and `SlotWrapper` component used internally

Fix this by adding set of components, which should not be stubbed and "whitelisting" SlotWrapper component and components created for slots

I find this approach way more clearer in terms of types, than adding extra field like "doNotStub" to any component, like it was done in @vue/test-utils 1.x 