### PR TITLE
feat: add @vue/compat initial support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
     - run: yarn install
     - run: yarn lint
     - run: yarn test
+    - run: yarn test:compat
     - run: yarn build
       env:
         CI: true
     - run: yarn test:build
+    - run: yarn test:compat:build
     - run: yarn tsd
     - run: yarn vue-tsc

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = {
   preset: 'ts-jest',
   globals: {
@@ -14,5 +16,5 @@ module.exports = {
     '^.+\\js$': 'babel-jest'
   },
   moduleFileExtensions: ['vue', 'js', 'json', 'jsx', 'ts', 'tsx', 'node'],
-  setupFiles: ['./setup.js']
+  setupFiles: [path.resolve(__dirname, './setup.js')]
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "15.12.4",
     "@types/pretty": "^2.0.0",
     "@vue/babel-plugin-jsx": "^1.0.6",
+    "@vue/compat": "^3.1.2",
     "@vue/compiler-dom": "^3.1.2",
     "@vue/compiler-sfc": "3.1.2",
     "babel-jest": "^26.6.3",
@@ -55,8 +56,10 @@
     "email": "lachlan.miller.1990@outlook.com"
   },
   "scripts": {
-    "test": "yarn jest --runInBand tests",
-    "test:build": "yarn jest --runInBand tests -use-build",
+    "test": "yarn jest --runInBand tests/",
+    "test:compat": "yarn jest -c tests-compat/jest-compat.config.js --runInBand tests-compat/",
+    "test:build": "yarn jest --runInBand tests/ -use-build",
+    "test:compat:build": "yarn jest -c tests-compat/jest-compat.config.js --runInBand tests-compat/ -use-build",
     "tsd": "tsc -p test-dts/tsconfig.tsd.json",
     "build": "yarn rollup -c rollup.config.js",
     "lint": "prettier -c --parser typescript \"(src|tests)/**/*.ts?(x)\"",

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -56,7 +56,12 @@ const createTransitionStub = ({
     return h(name, {}, ctx.$slots)
   }
 
-  return defineComponent({ name, render, props })
+  return defineComponent({
+    name,
+    compatConfig: { MODE: 3, RENDER_FUNCTION: false },
+    render,
+    props
+  })
 }
 
 const resolveComponentStubByName = (

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -8,6 +8,7 @@ import { FindAllComponentsSelector } from '../types'
 import { getOriginalVNodeTypeFromStub } from '../stubs'
 import { isComponent } from '../utils'
 import { matchName } from './matchName'
+import { convertLegacyVueExtendSelector } from './vueCompatSupport'
 
 /**
  * Detect whether a selector matches a VNode
@@ -17,8 +18,10 @@ import { matchName } from './matchName'
  */
 export function matches(
   node: VNode,
-  selector: FindAllComponentsSelector
+  rawSelector: FindAllComponentsSelector
 ): boolean {
+  const selector = convertLegacyVueExtendSelector(rawSelector)
+
   // do not return none Vue components
   if (!node.component) return false
 

--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -1,15 +1,21 @@
+import * as Vue from 'vue'
+import type { ComponentOptions } from 'vue'
 import { FindAllComponentsSelector } from '../types'
 
+function isCompatEnabled(key: string): boolean {
+  return (Vue as any).compatUtils?.isCompatEnabled(key) ?? false
+}
+
 export function convertLegacyVueExtendSelector(
-  selector: any
+  selector: FindAllComponentsSelector
 ): FindAllComponentsSelector {
-  if (
-    typeof selector === 'function' &&
-    selector.name === 'SubVue' &&
-    selector.options
-  ) {
-    return selector.options
+  if (!isCompatEnabled('GLOBAL_EXTEND') || typeof selector !== 'function') {
+    return selector
   }
 
-  return selector
+  // @ts-ignore Vue.extend is part of Vue2 compat API, types are missing
+  const fakeCmp = Vue.extend({})
+
+  // @ts-ignore TypeScript does not allow access of properties on functions
+  return fakeCmp.super === selector.super ? selector.options : selector
 }

--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -1,0 +1,15 @@
+import { FindAllComponentsSelector } from '../types'
+
+export function convertLegacyVueExtendSelector(
+  selector: any
+): FindAllComponentsSelector {
+  if (
+    typeof selector === 'function' &&
+    selector.name === 'SubVue' &&
+    selector.options
+  ) {
+    return selector.options
+  }
+
+  return selector
+}

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -1,0 +1,38 @@
+import * as Vue from '@vue/compat'
+import { mount } from '../src'
+
+const { configureCompat, extend, defineComponent } = Vue as any
+
+describe('@vue/compat build', () => {
+  it.each([true, false])(
+    'correctly renders transition when RENDER_FUNCTION compat is %p',
+    (RENDER_FUNCTION) => {
+      configureCompat({ MODE: 3, RENDER_FUNCTION })
+
+      const Component = defineComponent({
+        template: '<transition><div class="hello"></div></transition>'
+      })
+      const wrapper = mount(Component)
+
+      expect(wrapper.find('.hello').exists()).toBe(true)
+    }
+  )
+
+  it('finds components declared with legacy Vue.extend', () => {
+    configureCompat({ MODE: 3, GLOBAL_EXTEND: true })
+
+    const LegacyComponent = extend({
+      template: '<div>LEGACY</div>'
+    })
+
+    const Component = defineComponent({
+      components: {
+        LegacyComponent
+      },
+      template: '<div><legacy-component /></div>'
+    })
+    const wrapper = mount(Component)
+
+    expect(wrapper.findComponent(LegacyComponent).exists()).toBe(true)
+  })
+})

--- a/tests-compat/jest-compat.config.js
+++ b/tests-compat/jest-compat.config.js
@@ -1,0 +1,8 @@
+const originalJestConfig = require('../jest.config')
+
+module.exports = {
+  ...originalJestConfig,
+  moduleNameMapper: {
+    '^vue$': '@vue/compat'
+  }
+}

--- a/types/compat.ts
+++ b/types/compat.ts
@@ -1,0 +1,3 @@
+declare module '@vue/compat' {
+  export * from 'vue'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,6 +1795,11 @@
     html-tags "^3.1.0"
     svg-tags "^1.0.0"
 
+"@vue/compat@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@vue/compat/-/compat-3.1.2.tgz#066765421f2d872350f1faec841ceca32858111e"
+  integrity sha512-6pS22V01LmvkPMtpZvgk0udtR3pNTfxvFR+E4Ut+H9HHusyGf7Gx+PnQwnmawGOxuATNGzfasMaxIkQpbdT8jQ==
+
 "@vue/compiler-core@3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.1.1.tgz#4f2c5d70eabd454675714cc8bd2b97f6a8efb196"


### PR DESCRIPTION
Vue 3.1 brings compat build, which is extremely important milestone in migrating huge codebases to Vue3.
`@vue/test-utils` plays surprisingly well with compat build and codebase in compat mode with only few changes required in code

Why changes are required? [Migration guide](https://v3.vuejs.org/guide/migration/migration-build.html) suggests enabling features via `configureCompat` as part of certain migration steps. If `RENDER_FUNCTION` feature is enabled, signature of render function will be similar to Vue2, so our stubs will not render slots. Luckily, we can override it, by explicitly setting `compatConfig` on our stub components (this has no effect if no compat build is in play).

Additionally a few magic hops are required for example for finding components declared with `Vue.extend`.

Please, take a note - this is not a complete changes list (for example `setValue` should take into account that model event might be set back to legacy "input" if `COMPONENT_V_MODEL` flag is in play), but is a foundation introducing testing compat build to CI and a couple of fixes