### PR TITLE
fix: support passing functional components as stub implementation

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -182,7 +182,7 @@ export function stubComponents(
       }
 
       // case 2: custom implementation
-      if (stub && typeof stub === 'object') {
+      if (stub && stub !== true) {
         // pass the props and children, for advanced stubbing
         return [stubs[name], props, children, patchFlag, dynamicProps]
       }

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -212,6 +212,32 @@ describe('mounting options: stubs', () => {
     expect(wrapper.html()).toBe('<div>foo stub</div>')
   })
 
+  it('uses functional component as a custom stub', () => {
+    const FooStub = () => h('div', 'foo stub')
+    const Foo = {
+      name: 'Foo',
+      render() {
+        return h('div', 'real foo')
+      }
+    }
+
+    const Comp = {
+      render() {
+        return h(Foo)
+      }
+    }
+
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          Foo: FooStub
+        }
+      }
+    })
+
+    expect(wrapper.html()).toBe('<div>foo stub</div>')
+  })
+
   it('uses an sfc as a custom stub', () => {
     const created = jest.fn()
     const HelloComp = {


### PR DESCRIPTION
Current check for type of stub (`typeof stub === 'object'`) is too restrictive and does not take into account functional components. Fix this

As a side effect, this also fix using legacy components as stubs when using `@vue/compat`