### PR TITLE
Support legacy functional components in compat build

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -38,6 +38,7 @@ import { attachEmitListener } from './emit'
 import { createDataMixin } from './dataMixin'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { createStub, stubComponents } from './stubs'
+import { isLegacyFunctionalComponent } from './utils/vueCompatSupport'
 
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
@@ -223,7 +224,10 @@ export function mount(
   // normalise the incoming component
   let component: DefineComponent
 
-  if (isFunctionalComponent(originalComponent)) {
+  if (
+    isFunctionalComponent(originalComponent) ||
+    isLegacyFunctionalComponent(originalComponent)
+  ) {
     component = defineComponent({
       setup:
         (_, { attrs, slots }) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,3 +109,10 @@ export function textContent(element: Element): string {
     ? element.textContent?.trim() ?? ''
     : ''
 }
+
+export function hasOwnProperty<O extends {}, P extends PropertyKey>(
+  obj: O,
+  prop: P
+): obj is O & Record<P, unknown> {
+  return obj.hasOwnProperty(prop)
+}

--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -1,6 +1,7 @@
 import * as Vue from 'vue'
 import type { ComponentOptions } from 'vue'
 import { FindAllComponentsSelector } from '../types'
+import { hasOwnProperty } from '../utils'
 
 function isCompatEnabled(key: string): boolean {
   return (Vue as any).compatUtils?.isCompatEnabled(key) ?? false
@@ -16,6 +17,22 @@ export function convertLegacyVueExtendSelector(
   // @ts-ignore Vue.extend is part of Vue2 compat API, types are missing
   const fakeCmp = Vue.extend({})
 
-  // @ts-ignore TypeScript does not allow access of properties on functions
-  return fakeCmp.super === selector.super ? selector.options : selector
+  return hasOwnProperty(selector, 'super') &&
+    hasOwnProperty(selector, 'options') &&
+    fakeCmp.super === selector.super
+    ? (selector.options as FindAllComponentsSelector)
+    : selector
+}
+
+export function isLegacyFunctionalComponent(component: unknown) {
+  if (!isCompatEnabled('COMPONENT_FUNCTIONAL')) {
+    return false
+  }
+
+  return (
+    component &&
+    typeof component === 'object' &&
+    hasOwnProperty(component, 'functional') &&
+    component.functional
+  )
 }

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -1,7 +1,7 @@
 import * as Vue from '@vue/compat'
 import { mount } from '../src'
 
-const { configureCompat, extend, defineComponent } = Vue as any
+const { configureCompat, extend, defineComponent, h } = Vue as any
 
 describe('@vue/compat build', () => {
   it.each([true, false])(
@@ -34,5 +34,33 @@ describe('@vue/compat build', () => {
     const wrapper = mount(Component)
 
     expect(wrapper.findComponent(LegacyComponent).exists()).toBe(true)
+  })
+
+  it('correctly mounts legacy functional component', () => {
+    configureCompat({ MODE: 3, COMPONENT_FUNCTIONAL: true })
+
+    const Component = defineComponent({
+      functional: true,
+      render: () => h('div', 'test')
+    })
+    const wrapper = mount(Component)
+
+    expect(wrapper.html()).toBe('<div>test</div>')
+  })
+
+  it('correctly mounts legacy functional component wrapped in Vue.extend', () => {
+    configureCompat({
+      MODE: 3,
+      GLOBAL_EXTEND: true,
+      COMPONENT_FUNCTIONAL: true
+    })
+
+    const Component = extend({
+      functional: true,
+      render: () => h('div', 'test')
+    })
+    const wrapper = mount(Component)
+
+    expect(wrapper.html()).toBe('<div>test</div>')
   })
 })


### PR DESCRIPTION
~~Marked as draft, depends on #698 being merged~~
Ready to rock!

This PR adds correct handling for legacy functional components (`{ functional: true }`) when using compat build
