### PR TITLE
fix: find component by its definition when using stub without name

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -24,7 +24,8 @@ interface StubOptions {
   renderStubDefaultSlot?: boolean
 }
 
-const stubsMap: WeakMap<ComponentOptions, VNodeTypes> = new WeakMap()
+const stubsMap: WeakMap<ConcreteComponent, VNodeTypes> = new WeakMap()
+
 export const getOriginalVNodeTypeFromStub = (
   type: ComponentOptions
 ): VNodeTypes | undefined => stubsMap.get(type)
@@ -198,6 +199,7 @@ export function stubComponents(
 
       // case 2: custom implementation
       if (stub && stub !== true) {
+        stubsMap.set(stubs[name], type)
         // pass the props and children, for advanced stubbing
         return [stubs[name], props, children, patchFlag, dynamicProps]
       }

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -122,6 +122,24 @@ describe('findComponent', () => {
     expect(wrapper.findComponent(Hello).exists()).toBe(true)
   })
 
+  it('finds a component by its definition when using stub without name', () => {
+    const StubWithoutName = {
+      template: '<div>stub-without-name</div>'
+    }
+
+    const Component = {
+      template: '<div><other-name /></div>',
+      components: {
+        OtherName: Hello
+      }
+    }
+
+    const wrapper = mount(Component, {
+      global: { stubs: { Hello: StubWithoutName } }
+    })
+    expect(wrapper.findComponent(Hello).exists()).toBe(true)
+  })
+
   it('finds a component without a name by its locally assigned name', () => {
     const Component = {
       template: '<div><component-without-name/></div>',


### PR DESCRIPTION
Follow-up of #696 

When we're stubbing component (no matter with `mount` or `shallow: true`) we still want to find a component by searching original component definition