### PR TITLE
fix: findComponent should work using same stub for different components

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -31,7 +31,7 @@ interface StubOptions {
 const stubsMap: WeakMap<ConcreteComponent, VNodeTypes> = new WeakMap()
 
 export const getOriginalVNodeTypeFromStub = (
-  type: ComponentOptions
+  type: ConcreteComponent
 ): VNodeTypes | undefined => stubsMap.get(type)
 
 const doNotStubComponents: WeakSet<ConcreteComponent> = new WeakSet()
@@ -213,10 +213,17 @@ export function stubComponents(
       }
 
       // case 2: custom implementation
-      if (stub && stub !== true) {
-        stubsMap.set(stub, type)
+      if (isComponent(stub)) {
+        const stubFn = isFunctionalComponent(stub) ? stub : null
+
+        const specializedStub: ConcreteComponent = stubFn
+          ? (...args) => stubFn(...args)
+          : { ...stub }
+
+        specializedStub.props = stub.props
+        stubsMap.set(specializedStub, type)
         // pass the props and children, for advanced stubbing
-        return [stub, props, children, patchFlag, dynamicProps]
+        return [specializedStub, props, children, patchFlag, dynamicProps]
       }
 
       if (stub === false) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,5 @@
 import { GlobalMountOptions } from './types'
-import {
-  Component,
-  ComponentOptions,
-  ComputedOptions,
-  FunctionalComponent,
-  VNodeTypes
-} from 'vue'
+import { ComponentOptions, ConcreteComponent, FunctionalComponent } from 'vue'
 import { config } from './config'
 
 function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
@@ -78,8 +72,13 @@ export function isClassComponent(component: unknown) {
   return typeof component === 'function' && '__vccOpts' in component
 }
 
-export function isComponent(component: unknown): component is ComponentOptions {
-  return typeof component === 'object' || typeof component === 'function'
+export function isComponent(
+  component: unknown
+): component is ConcreteComponent {
+  return Boolean(
+    component &&
+      (typeof component === 'object' || typeof component === 'function')
+  )
 }
 
 export function isFunctionalComponent(

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -140,6 +140,22 @@ describe('findComponent', () => {
     expect(wrapper.findComponent(Hello).exists()).toBe(true)
   })
 
+  it('finds a component by its definition when stub is reused', () => {
+    const reusedStub = { template: '<div>universal stub</div>' }
+
+    const wrapper = mount(compA, {
+      global: {
+        stubs: {
+          Hello: reusedStub,
+          compB: reusedStub
+        }
+      }
+    })
+
+    expect(wrapper.findComponent(Hello).exists()).toBe(true)
+    expect(wrapper.findComponent(compB).exists()).toBe(true)
+  })
+
   it('finds a component without a name by its locally assigned name', () => {
     const Component = {
       template: '<div><component-without-name/></div>',


### PR DESCRIPTION
This one is a bit tricky. Sometimes we're reusing same stub for multiple components (it's fine when it is some kind of dummy stub). In this case previous naive approach taken in #704 will fail because we're having `stub -> type` mapping with stub as key.

To fix this, we're now generating unique stub (a very thin wrapper), making sure we could distinguish "stubs" for componentA and componentB when they are using same stub in `mount`

Marking as draft before #704 is merged