### PR TITLE
feat(compat): correctly stub components, wrapped in Vue.extend

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,7 +91,7 @@ export function isFunctionalComponent(
 export function isObjectComponent(
   component: unknown
 ): component is ComponentOptions {
-  return typeof component !== 'function'
+  return Boolean(component && typeof component === 'object')
 }
 
 // https://stackoverflow.com/questions/15458876/check-if-a-string-is-html-or-not/15458987#answer-15458968

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -8,7 +8,7 @@ import { FindAllComponentsSelector } from '../types'
 import { getOriginalVNodeTypeFromStub } from '../stubs'
 import { isComponent } from '../utils'
 import { matchName } from './matchName'
-import { convertLegacyVueExtendSelector } from './vueCompatSupport'
+import { unwrapLegacyVueExtendComponent } from './vueCompatSupport'
 
 /**
  * Detect whether a selector matches a VNode
@@ -20,7 +20,7 @@ export function matches(
   node: VNode,
   rawSelector: FindAllComponentsSelector
 ): boolean {
-  const selector = convertLegacyVueExtendSelector(rawSelector)
+  const selector = unwrapLegacyVueExtendComponent(rawSelector)
 
   // do not return none Vue components
   if (!node.component) return false

--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -1,27 +1,34 @@
 import * as Vue from 'vue'
 import type { ComponentOptions } from 'vue'
-import { FindAllComponentsSelector } from '../types'
 import { hasOwnProperty } from '../utils'
 
 function isCompatEnabled(key: string): boolean {
   return (Vue as any).compatUtils?.isCompatEnabled(key) ?? false
 }
 
-export function convertLegacyVueExtendSelector(
-  selector: FindAllComponentsSelector
-): FindAllComponentsSelector {
-  if (!isCompatEnabled('GLOBAL_EXTEND') || typeof selector !== 'function') {
-    return selector
+export function isLegacyExtendedComponent(component: unknown): component is {
+  (): Function
+  super: Function
+  options: ComponentOptions
+} {
+  if (!isCompatEnabled('GLOBAL_EXTEND') || typeof component !== 'function') {
+    return false
   }
 
   // @ts-ignore Vue.extend is part of Vue2 compat API, types are missing
   const fakeCmp = Vue.extend({})
 
-  return hasOwnProperty(selector, 'super') &&
-    hasOwnProperty(selector, 'options') &&
-    fakeCmp.super === selector.super
-    ? (selector.options as FindAllComponentsSelector)
-    : selector
+  return (
+    hasOwnProperty(component, 'super') &&
+    hasOwnProperty(component, 'options') &&
+    fakeCmp.super === component.super
+  )
+}
+
+export function unwrapLegacyVueExtendComponent<T>(
+  selector: T
+): T | ComponentOptions {
+  return isLegacyExtendedComponent(selector) ? selector.options : selector
 }
 
 export function isLegacyFunctionalComponent(component: unknown) {

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -63,4 +63,34 @@ describe('@vue/compat build', () => {
 
     expect(wrapper.html()).toBe('<div>test</div>')
   })
+
+  it('correctly stubs legacy component wrapped in Vue.extend', () => {
+    configureCompat({
+      MODE: 3,
+      GLOBAL_EXTEND: true
+    })
+
+    const Foo = extend({
+      name: 'Foo',
+      template: '<div>original</div>'
+    })
+
+    const FooStub = { template: '<div>stubbed</div>' }
+
+    const Component = {
+      components: { NamedAsNotFoo: Foo },
+      template: '<named-as-not-foo />'
+    }
+
+    debugger
+    const wrapper = mount(Component, {
+      global: {
+        stubs: {
+          Foo: FooStub
+        }
+      }
+    })
+
+    expect(wrapper.html()).toBe('<div>stubbed</div>')
+  })
 })


### PR DESCRIPTION
Draft, waiting for #707 and #698

This PR adds correct extraction of component name for components created by `Vue.extend`
