### PR TITLE
fix(shallow): correctly stub anonymous components

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -172,11 +172,6 @@ export function stubComponents(
       const registeredName = getComponentRegisteredName(instance, type)
       const componentName = type['name'] || type['displayName']
 
-      // No name found?
-      if (!registeredName && !componentName) {
-        return renderStubDefaultSlot || !shallow ? args : ['stub']
-      }
-
       let stub = null
       let name = null
 

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -670,4 +670,28 @@ describe('mounting options: stubs', () => {
       )
     })
   })
+
+  it('renders stub for anonymous component when using shallow mount', () => {
+    const AnonymousComponent = defineComponent({
+      template: `<div class="original"><slot></slot></div>`
+    })
+
+    const WrapperComponent = defineComponent({
+      computed: {
+        cmp() {
+          return AnonymousComponent
+        }
+      },
+      template: `<component :is="cmp">test</component>`
+    })
+
+    const wrapper = mount(WrapperComponent, {
+      shallow: true,
+      global: {
+        renderStubDefaultSlot: true
+      }
+    })
+
+    expect(wrapper.html()).toBe('<anonymous-stub>test</anonymous-stub>')
+  })
 })

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -160,8 +160,8 @@ describe('shallowMount', () => {
     expect(wrapper.html()).toEqual(
       '<div>Override</div>\n' +
         '<component-with-input-stub></component-with-input-stub>\n' +
-        '<stub></stub>\n' +
-        '<stub></stub>\n' +
+        '<anonymous-stub></anonymous-stub>\n' +
+        '<anonymous-stub></anonymous-stub>\n' +
         '<with-props-stub></with-props-stub>'
     )
   })


### PR DESCRIPTION
#607 [introduced](https://github.com/vuejs/vue-test-utils-next/pull/607/files#diff-840c8e77baceaebec1b759efa8bbb8505149fbd81c64bb120801388b66d839c4R162) a bug, when anonymous component will not be stubbed even when using `shallow: true`

Remove this special case - now it is properly handled by rest of the code (the only difference is that stubs will be now named as `anonymous-stub` which is kind of expected)