### PR TITLE
fix(compat): correctly render default slot in stub if requested

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -53,6 +53,7 @@ export const createStub = ({
 
   return defineComponent({
     name: name || anonName,
+    compatConfig: { MODE: 3, RENDER_FUNCTION: false },
     render,
     props: propsDeclaration
   })

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -4,17 +4,38 @@ import { mount } from '../src'
 const { configureCompat, extend, defineComponent, h } = Vue as any
 
 describe('@vue/compat build', () => {
-  it.each([true, false])(
-    'correctly renders transition when RENDER_FUNCTION compat is %p',
+  describe.each([true, false])(
+    'when RENDER_FUNCTION compat is %p',
     (RENDER_FUNCTION) => {
-      configureCompat({ MODE: 3, RENDER_FUNCTION })
-
-      const Component = defineComponent({
-        template: '<transition><div class="hello"></div></transition>'
+      beforeEach(() => {
+        configureCompat({ MODE: 3, RENDER_FUNCTION })
       })
-      const wrapper = mount(Component)
 
-      expect(wrapper.find('.hello').exists()).toBe(true)
+      it('renders default slot content when renderStubDefaultSlot is true', () => {
+        const Foo = { template: '<div><slot></slot></div>' }
+        const Component = {
+          components: { Foo },
+          template: '<foo>test</foo>'
+        }
+
+        const wrapper = mount(Component, {
+          global: {
+            stubs: { Foo: true },
+            renderStubDefaultSlot: true
+          }
+        })
+
+        expect(wrapper.html()).toBe('<foo-stub>test</foo-stub>')
+      })
+
+      it('correctly renders transition', () => {
+        const Component = defineComponent({
+          template: '<transition><div class="hello"></div></transition>'
+        })
+        const wrapper = mount(Component)
+
+        expect(wrapper.find('.hello').exists()).toBe(true)
+      })
     }
   )
 
@@ -82,7 +103,6 @@ describe('@vue/compat build', () => {
       template: '<named-as-not-foo />'
     }
 
-    debugger
     const wrapper = mount(Component, {
       global: {
         stubs: {


### PR DESCRIPTION
If we will not pass `compatConfig` to `createStub` - slots might be located in other place when `RENDER_FUNCTION` compat is enabled

As usual - specifying `compatConfig` has no effect when non-compat build is used