### PR TITLE
fix(compat): do not stub legacy functional component root

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,0 @@
-export const MOUNT_COMPONENT_REF = 'VTU_COMPONENT'
-export const MOUNT_PARENT_NAME = 'VTU_ROOT'

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -37,7 +37,6 @@ import { processSlot } from './utils/compileSlots'
 import { createWrapper, VueWrapper } from './vueWrapper'
 import { attachEmitListener } from './emit'
 import { createDataMixin } from './dataMixin'
-import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { createStub, stubComponents, addToDoNotStubComponents } from './stubs'
 import { isLegacyFunctionalComponent } from './utils/vueCompatSupport'
 
@@ -333,6 +332,7 @@ export function mount(
     ]
   }
 
+  const MOUNT_COMPONENT_REF = 'VTU_COMPONENT'
   // we define props as reactive so that way when we update them with `setProps`
   // Vue's reactivity system will cause a rerender.
   const props = reactive({
@@ -348,7 +348,7 @@ export function mount(
 
   // create the wrapper component
   const Parent = defineComponent({
-    name: MOUNT_PARENT_NAME,
+    name: 'VTU_ROOT',
     render() {
       // https://github.com/vuejs/vue-test-utils-next/issues/651
       // script setup components include an empty `expose` array as part of the

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -38,7 +38,7 @@ import { createWrapper, VueWrapper } from './vueWrapper'
 import { attachEmitListener } from './emit'
 import { createDataMixin } from './dataMixin'
 import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
-import { createStub, stubComponents } from './stubs'
+import { createStub, stubComponents, addToDoNotStubComponents } from './stubs'
 import { isLegacyFunctionalComponent } from './utils/vueCompatSupport'
 
 // NOTE this should come from `vue`
@@ -235,12 +235,14 @@ export function mount(
         () =>
           h(originalComponent, attrs, slots)
     })
+    addToDoNotStubComponents(originalComponent)
   } else if (isObjectComponent(originalComponent)) {
     component = { ...originalComponent }
   } else {
     component = originalComponent
   }
 
+  addToDoNotStubComponents(component)
   const el = document.createElement('div')
 
   if (options?.attachTo) {
@@ -362,6 +364,7 @@ export function mount(
       return h(component, props, slots)
     }
   })
+  addToDoNotStubComponents(Parent)
 
   const setProps = (newProps: Record<string, unknown>) => {
     for (const [k, v] of Object.entries(newProps)) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -12,7 +12,6 @@ import {
   ConcreteComponent
 } from 'vue'
 import { hyphenate } from './utils/vueShared'
-import { MOUNT_COMPONENT_REF, MOUNT_PARENT_NAME } from './constants'
 import { matchName } from './utils/matchName'
 import { isComponent, isFunctionalComponent, isObjectComponent } from './utils'
 import { ComponentInternalInstance } from '@vue/runtime-core'

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -126,18 +126,6 @@ const getComponentName = (type: VNodeTypes): string => {
   return ''
 }
 
-const isHTMLElement = (type: VNodeTypes) => typeof type === 'string'
-
-const isCommentOrFragment = (type: VNodeTypes) => typeof type === 'symbol'
-
-const isParent = (type: VNodeTypes) =>
-  isComponent(type) && type['name'] === MOUNT_PARENT_NAME
-
-const isMountedComponent = (
-  type: VNodeTypes,
-  props: ({ [key: string]: unknown } & VNodeProps) | null | undefined
-) => isComponent(type) && props && props['ref'] === MOUNT_COMPONENT_REF
-
 export function stubComponents(
   stubs: Record<any, any> = {},
   shallow: boolean = false,
@@ -170,19 +158,6 @@ export function stubComponents(
         undefined,
         children
       ]
-    }
-
-    // args[0] can either be:
-    // 1. a HTML tag (div, span...)
-    // 2. An object of component options, such as { name: 'foo', render: [Function], props: {...} }
-    // Depending what it is, we do different things.
-    if (
-      isHTMLElement(type) ||
-      isCommentOrFragment(type) ||
-      isParent(type) ||
-      isMountedComponent(type, props)
-    ) {
-      return args
     }
 
     if (isComponent(type) || isFunctionalComponent(type)) {
@@ -259,6 +234,7 @@ export function stubComponents(
       }
     }
 
+    // do not stub anything what is not a component
     return args
   })
 }

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -48,6 +48,23 @@ describe('@vue/compat build', () => {
     expect(wrapper.html()).toBe('<div>test</div>')
   })
 
+  it('does not stub root legacy functional component when shallow', () => {
+    configureCompat({
+      MODE: 3,
+      GLOBAL_EXTEND: true,
+      COMPONENT_FUNCTIONAL: true
+    })
+
+    const Foo = {
+      name: 'Foo',
+      functional: true,
+      render: () => h('div', 'test')
+    }
+    const wrapper = mount(Foo, { shallow: true })
+
+    expect(wrapper.html()).toBe('<div>test</div>')
+  })
+
   it('correctly mounts legacy functional component wrapped in Vue.extend', () => {
     configureCompat({
       MODE: 3,


### PR DESCRIPTION
This originally started as fixing obvious issue - we should not stub root when it is legacy functional component (`{ functional: true }`)

But it turns out that instead of adding more & more conditions we could switch to explicitly adding our Parent & root component to do-not-stub list and this greatly simplifies logic