### PR TITLE
fix: correctly pass component definition as slot mounting option

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -263,7 +263,7 @@ export function mount(
   function slotToFunction(slot: Slot) {
     if (typeof slot === 'object') {
       if ('render' in slot && slot.render) {
-        return slot.render
+        return () => h(slot)
       }
 
       if ('template' in slot && slot.template) {

--- a/tests/mountingOptions/slots.spec.ts
+++ b/tests/mountingOptions/slots.spec.ts
@@ -89,7 +89,7 @@ describe('slots', () => {
         '' +
           '<div class="named">' +
           '<div id="root">' +
-          '<div id="msg"></div>' +
+          '<div id="msg">Hello world</div>' +
           '</div>' +
           '</div>'
       )
@@ -214,16 +214,25 @@ describe('slots', () => {
     const Parent = defineComponent({
       mounted() {
         parentMounted()
+      },
+      render() {
+        return h(this.$slots.default!)
       }
     })
 
     const Child = defineComponent({
+      render() {
+        return h('span')
+      },
       mounted() {
         childMounted()
       }
     })
 
     const wrapper = mount(Parent, {
+      global: {
+        components: { Child }
+      },
       slots: {
         default: Child
       }

--- a/tests/mountingOptions/slots.spec.ts
+++ b/tests/mountingOptions/slots.spec.ts
@@ -1,6 +1,6 @@
-import { h } from 'vue'
+import { defineComponent, h } from 'vue'
 
-import { mount } from '../../src'
+import { flushPromises, mount } from '../../src'
 import Hello from '../components/Hello.vue'
 import WithProps from '../components/WithProps.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
@@ -205,5 +205,33 @@ describe('slots', () => {
     expect(wrapper.find('.foo').exists()).toBe(true)
     expect(wrapper.find('span').text()).toBe('Default')
     expect(wrapper.find('#with-props').text()).toBe('props-msg')
+  })
+
+  it('triggers child component lifecycles', async () => {
+    const parentMounted = jest.fn()
+    const childMounted = jest.fn()
+
+    const Parent = defineComponent({
+      mounted() {
+        parentMounted()
+      }
+    })
+
+    const Child = defineComponent({
+      mounted() {
+        childMounted()
+      }
+    })
+
+    const wrapper = mount(Parent, {
+      slots: {
+        default: Child
+      }
+    })
+
+    await flushPromises()
+
+    expect(parentMounted).toHaveBeenCalled()
+    expect(childMounted).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
We were not passing the entire component to `slots`, just the `render` function, so things like the lifecycle hooks were not executed.

closes #727