### PR TITLE
refactor: use defineEmits

### DIFF
--- a/tests/components/EmitsEventScriptSetup.vue
+++ b/tests/components/EmitsEventScriptSetup.vue
@@ -3,9 +3,9 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, defineEmit } from 'vue'
+import { onMounted } from 'vue'
 
-const emit = defineEmit(['bar'])
+const emit = defineEmits(['bar'])
 
 const click = () => emit('bar', 'click')
 


### PR DESCRIPTION
`defineEmit` is replaced by `defineEmits` and using the deprecated version fails the test with Vue 3.2.0-beta.1