### PR TITLE
fix(compat): Do not wrap legacy options component with extra wrap

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -9,7 +9,6 @@ import {
   ComponentOptionsWithArrayProps,
   ComponentOptionsWithoutProps,
   ExtractPropTypes,
-  WritableComputedOptions,
   AppConfig,
   VNodeProps,
   ComponentOptionsMixin,
@@ -38,7 +37,10 @@ import { createWrapper, VueWrapper } from './vueWrapper'
 import { attachEmitListener } from './emit'
 import { createDataMixin } from './dataMixin'
 import { createStub, stubComponents, addToDoNotStubComponents } from './stubs'
-import { isLegacyFunctionalComponent } from './utils/vueCompatSupport'
+import {
+  isLegacyFunctionalComponent,
+  unwrapLegacyVueExtendComponent
+} from './utils/vueCompatSupport'
 
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
@@ -218,10 +220,11 @@ export function mount<
 
 // implementation
 export function mount(
-  originalComponent: any,
+  inputComponent: any,
   options?: MountingOptions<any>
 ): VueWrapper<any> {
   // normalise the incoming component
+  let originalComponent = unwrapLegacyVueExtendComponent(inputComponent)
   let component: ConcreteComponent
 
   if (

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -130,4 +130,17 @@ describe('@vue/compat build', () => {
 
     expect(wrapper.html()).toBe('<div>stubbed</div>')
   })
+
+  it('wrapper.vm points to correct instance when component is wrapped with Vue.extend', () => {
+    const Component = extend({
+      data() {
+        return { foo: 'bar' }
+      },
+      template: '<div></div>'
+    })
+
+    const wrapper = mount(Component)
+
+    expect(wrapper.vm.foo).toBe('bar')
+  })
 })


### PR DESCRIPTION
New day, new compat issue (this one discovered by working on migrating `bootsrap-vue` to compat build)

We need to unwrap component before mount, or (since typeof component will be function after `Vue.extend`)) it will be treated as function component and wrapped inside another one with "setup"