### PR TITLE
refactor: use jest.advanceTimersByTime in async test

### DIFF
--- a/tests/features/async-components.spec.ts
+++ b/tests/features/async-components.spec.ts
@@ -52,11 +52,11 @@ describe('defineAsyncComponent', () => {
     })
 
     const wrapper = mount(Comp, { global: { config } })
-    jest.runTimersToTime(35)
+    jest.advanceTimersByTime(35)
     await flushPromises()
     expect(wrapper.html()).toContain('Loading Component')
 
-    jest.runTimersToTime(100)
+    jest.advanceTimersByTime(100)
     await flushPromises()
     expect(wrapper.html()).toContain('Async Component')
   })


### PR DESCRIPTION
`jest.runTimersToTime` is deprecated and removed in jest 27