### PR TITLE
fix: Always wrap string passed to slot in a helper component

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -27,7 +27,6 @@ import {
 import { MountingOptions, Slot } from './types'
 import {
   isFunctionalComponent,
-  isHTML,
   isObjectComponent,
   mergeGlobalProperties,
   isObject
@@ -281,14 +280,7 @@ export function mount(
     }
 
     if (typeof slot === 'string') {
-      // if it is HTML we process and render it using h
-      if (isHTML(slot)) {
-        return (props: VNodeProps) => h(processSlot(slot), props)
-      }
-      // otherwise it is just a string so we just return it as-is
-      else {
-        return () => slot
-      }
+      return (props: VNodeProps) => h(processSlot(slot), props)
     }
 
     throw Error(`Invalid slot received.`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,20 +93,6 @@ export function isObjectComponent(
   return Boolean(component && typeof component === 'object')
 }
 
-// https://stackoverflow.com/questions/15458876/check-if-a-string-is-html-or-not/15458987#answer-15458968
-export function isHTML(str: string) {
-  var a = document.createElement('div')
-  a.innerHTML = str
-
-  for (let c = a.childNodes, i = c.length; i--; ) {
-    if (c[i].nodeType == 1) {
-      return true
-    }
-  }
-
-  return false
-}
-
 export function textContent(element: Element): string {
   // we check if the element is a comment first
   // to return an empty string in that case, instead of the comment content

--- a/tests/components/ComponentWithSlots.vue
+++ b/tests/components/ComponentWithSlots.vue
@@ -12,6 +12,11 @@
     <div class="scoped">
       <slot name="scoped" v-bind="{ aBoolean, aString, anObject }" />
     </div>
+    <table class="insideTable">
+      <colgroup>
+        <slot name="insideTable" />
+      </colgroup>
+    </table>
     <div class="scopedWithDefault">
       <slot name="scopedWithDefault" v-bind="{ aBoolean, aString, anObject }">
         boolean: {{ aBoolean }} string: {{ aString }} object: {{ anObject }}

--- a/tests/mountingOptions/slots.spec.ts
+++ b/tests/mountingOptions/slots.spec.ts
@@ -190,6 +190,16 @@ describe('slots', () => {
 
       expect(wrapper.find('.scoped').text()).toEqual('Just a plain true string')
     })
+
+    it('allows passing a scoped slot via string with no HTML inside without template tag', () => {
+      const wrapper = mount(ComponentWithSlots, {
+        slots: {
+          scoped: 'Just a plain {{ params.aBoolean }} {{ params.aString }}'
+        }
+      })
+
+      expect(wrapper.find('.scoped').text()).toEqual('Just a plain true string')
+    })
   })
 
   it('supports an array of components', () => {

--- a/tests/mountingOptions/slots.spec.ts
+++ b/tests/mountingOptions/slots.spec.ts
@@ -16,7 +16,6 @@ describe('slots', () => {
           named: namedString
         }
       })
-      expect(wrapper.vm.$slots.default!()[0].children).toBe(defaultString)
       expect(wrapper.find('.default').text()).toBe(defaultString)
       expect(wrapper.find('.named').text()).toBe(namedString)
     })
@@ -34,6 +33,16 @@ describe('slots', () => {
 
       expect(wrapper.find('.defaultNested').exists()).toBe(true)
       expect(wrapper.find('.namedNested').exists()).toBe(true)
+    })
+
+    it('supports providing html string with tags valid only nested in some other tag', () => {
+      const wrapper = mount(ComponentWithSlots, {
+        slots: {
+          insideTable: '<col><col><col>'
+        }
+      })
+
+      expect(wrapper.findAll('.insideTable col')).toHaveLength(3)
     })
 
     it('supports providing a render function to slot', () => {


### PR DESCRIPTION
I've originally [encountered](https://github.com/bootstrap-vue/bootstrap-vue/blob/5bf6733/src/components/table/table-colgroup.spec.js#L31) this issue while porting bootstrap-vue to Vue3

All known (at least to me and in mentioned stack overflow :stuck_out_tongue: question) methods of checking if something is HTML reports false for `<col><col><col>` because `<col>` is considered valid tag only inside `table -> colgroup`

In order to fix that I simply removed check if it is HTML and always wrap slot provided as string into `<SlotWrapper>`
This has a downside - if code under test relies on knowing that slot will always have raw strings - it will be confused by wrapper. User could workaround it with passing slot as function:

```js
slots: {
  'some-slot': () => h('Something which should be just plain old string')
}
```

I consider this way more rare case, and what is more important - people who manipulate slot contents in that way are usually far more expert to understand the root cause of the issue and to discover (or find this PR) workaround.

For original issue - it took me a while to realize why slot work for certain HTML string and does not work for another when the only difference is tag
