### PR TITLE
chore(types): improve types of stubs option

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -312,7 +312,7 @@ type GlobalMountOptions = {
   plugins?: (Plugin | [Plugin, ...any[]])[]
   provide?: Record<any, any>
   renderStubDefaultSlot?: boolean
-  stubs?: Record<any, any>
+  stubs?: Stubs = Record<string, boolean | Component> | Array<string>
 }
 ```
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -468,7 +468,7 @@ export function mount(
         })
         // default stub.
         app.component(name, stubbed)
-      } else {
+      } else if (stub !== false) {
         // user has provided a custom implementation.
         app.component(name, stub)
       }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -428,7 +428,7 @@ export function mount(
   if (global.components) {
     for (const key of Object.keys(global.components)) {
       // avoid registering components that are stubbed twice
-      if (!global.stubs[key]) {
+      if (!(key in global.stubs)) {
         app.component(key, global.components[key])
       }
     }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -22,7 +22,6 @@ import {
 
 interface StubOptions {
   name: string
-  props?: any
   propsDeclaration?: any
   renderStubDefaultSlot?: boolean
 }
@@ -58,10 +57,7 @@ export const createStub = ({
   })
 }
 
-const createTransitionStub = ({
-  name,
-  props
-}: StubOptions): ComponentOptions => {
+const createTransitionStub = ({ name }: StubOptions): ComponentOptions => {
   const render = (ctx: ComponentPublicInstance) => {
     return h(name, {}, ctx.$slots)
   }
@@ -69,8 +65,7 @@ const createTransitionStub = ({
   return defineComponent({
     name,
     compatConfig: { MODE: 3, RENDER_FUNCTION: false },
-    render,
-    props
+    render
   })
 }
 
@@ -140,8 +135,7 @@ export function stubComponents(
     if (type === Transition && stubs['transition']) {
       return [
         createTransitionStub({
-          name: 'transition-stub',
-          propsDeclaration: undefined
+          name: 'transition-stub'
         }),
         undefined,
         children
@@ -152,8 +146,7 @@ export function stubComponents(
     if (type === TransitionGroup && stubs['transition-group']) {
       return [
         createTransitionStub({
-          name: 'transition-group-stub',
-          propsDeclaration: undefined
+          name: 'transition-group-stub'
         }),
         undefined,
         children

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -4,12 +4,11 @@ import {
   TransitionGroup,
   h,
   ComponentPublicInstance,
-  Slots,
   ComponentOptions,
   defineComponent,
-  VNodeProps,
   VNodeTypes,
-  ConcreteComponent
+  ConcreteComponent,
+  ComponentPropsOptions
 } from 'vue'
 import { hyphenate } from './utils/vueShared'
 import { matchName } from './utils/matchName'
@@ -22,7 +21,7 @@ import {
 
 interface StubOptions {
   name: string
-  propsDeclaration?: any
+  propsDeclaration?: ComponentPropsOptions
   renderStubDefaultSlot?: boolean
 }
 
@@ -53,7 +52,7 @@ export const createStub = ({
     name: name || anonName,
     compatConfig: { MODE: 3, RENDER_FUNCTION: false },
     render,
-    props: propsDeclaration
+    props: propsDeclaration || {}
   })
 }
 

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -18,6 +18,7 @@ import {
   isLegacyExtendedComponent,
   unwrapLegacyVueExtendComponent
 } from './utils/vueCompatSupport'
+import { Stub, Stubs } from './types'
 
 interface StubOptions {
   name: string
@@ -68,16 +69,13 @@ const createTransitionStub = ({ name }: StubOptions): ComponentOptions => {
   })
 }
 
-const resolveComponentStubByName = (
-  componentName: string,
-  stubs: Record<any, any>
-) => {
+const resolveComponentStubByName = (componentName: string, stubs: Stubs) => {
   if (Array.isArray(stubs) && stubs.length) {
     // ['Foo', 'Bar'] => { Foo: true, Bar: true }
     stubs = stubs.reduce((acc, current) => {
       acc[current] = true
       return acc
-    }, {})
+    }, {} as Record<string, Stub>)
   }
 
   for (const [stubKey, value] of Object.entries(stubs)) {
@@ -121,7 +119,7 @@ const getComponentName = (type: VNodeTypes): string => {
 }
 
 export function stubComponents(
-  stubs: Record<any, any> = {},
+  stubs: Stubs = {},
   shallow: boolean = false,
   renderStubDefaultSlot: boolean = false
 ) {
@@ -131,7 +129,7 @@ export function stubComponents(
     const type = nodeType as VNodeTypes
 
     // stub transition by default via config.global.stubs
-    if (type === Transition && stubs['transition']) {
+    if (type === Transition && 'transition' in stubs && stubs['transition']) {
       return [
         createTransitionStub({
           name: 'transition-stub'
@@ -142,7 +140,11 @@ export function stubComponents(
     }
 
     // stub transition-group by default via config.global.stubs
-    if (type === TransitionGroup && stubs['transition-group']) {
+    if (
+      type === TransitionGroup &&
+      'transition-group' in stubs &&
+      stubs['transition-group']
+    ) {
       return [
         createTransitionStub({
           name: 'transition-group-stub'

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,8 @@ import {
   Plugin,
   AppConfig,
   VNode,
-  VNodeProps
+  VNodeProps,
+  ConcreteComponent
 } from 'vue'
 
 interface RefSelector {
@@ -87,6 +88,8 @@ export interface MountingOptions<Props, Data = {}> {
   shallow?: boolean
 }
 
+export type Stub = boolean | ConcreteComponent
+
 export type GlobalMountOptions = {
   /**
    * Installs plugins on the component.
@@ -130,7 +133,7 @@ export type GlobalMountOptions = {
    * @default "{ transition: true, 'transition-group': true }"
    * @see https://next.vue-test-utils.vuejs.org/api/#global-stubs
    */
-  stubs?: Record<any, any>
+  stubs?: Record<string, Stub>
   /**
    * Allows rendering the default slot content, even when using
    * `shallow` or `shallowMount`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,8 @@ import {
   AppConfig,
   VNode,
   VNodeProps,
-  ConcreteComponent
+  ConcreteComponent,
+  DefineComponent
 } from 'vue'
 
 interface RefSelector {
@@ -88,7 +89,7 @@ export interface MountingOptions<Props, Data = {}> {
   shallow?: boolean
 }
 
-export type Stub = boolean | ConcreteComponent
+export type Stub = boolean | Component
 export type Stubs = Record<string, Stub> | Array<string>
 export type GlobalMountOptions = {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface MountingOptions<Props, Data = {}> {
 }
 
 export type Stub = boolean | ConcreteComponent
-
+export type Stubs = Record<string, Stub> | Array<string>
 export type GlobalMountOptions = {
   /**
    * Installs plugins on the component.
@@ -133,7 +133,7 @@ export type GlobalMountOptions = {
    * @default "{ transition: true, 'transition-group': true }"
    * @see https://next.vue-test-utils.vuejs.org/api/#global-stubs
    */
-  stubs?: Record<string, Stub>
+  stubs?: Stubs
   /**
    * Allows rendering the default slot content, even when using
    * `shallow` or `shallowMount`.


### PR DESCRIPTION
Minor types tweaks - getting rid of `any` in definition of stubs global config