### PR TITLE
fix: do not crash findComponent if ref is pointing to html element

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1143,6 +1143,10 @@ test('findComponent', () => {
 })
 ```
 
+:::warning
+If `ref` in component points to HTML element, `findComponent` will return empty wrapper. This is intended behaviour
+:::
+
 **NOTE** `getComponent` and `findComponent` will not work on functional components, because they do not have an internal Vue instance (this is what makes functional components more performant). That means the following will **not** work:
 
 ```js

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -159,8 +159,11 @@ export class VueWrapper<T extends ComponentPublicInstance>
   ): VueWrapper<T> {
     if (typeof selector === 'object' && 'ref' in selector) {
       const result = this.vm.$refs[selector.ref]
-      if (result) {
+      console.log(result)
+      if (result && !(result instanceof HTMLElement)) {
         return createWrapper(null, result as T)
+      } else {
+        return createWrapperError('VueWrapper')
       }
     }
 

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -159,7 +159,6 @@ export class VueWrapper<T extends ComponentPublicInstance>
   ): VueWrapper<T> {
     if (typeof selector === 'object' && 'ref' in selector) {
       const result = this.vm.$refs[selector.ref]
-      console.log(result)
       if (result && !(result instanceof HTMLElement)) {
         return createWrapper(null, result as T)
       } else {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -47,7 +47,16 @@ describe('findComponent', () => {
   it('finds component by ref', () => {
     const wrapper = mount(compA)
     // find by ref
-    expect(wrapper.findComponent({ ref: 'hello' })).toBeTruthy()
+    expect(wrapper.findComponent({ ref: 'hello' }).exists()).toBe(true)
+  })
+
+  it('does not find plain dom element by ref', () => {
+    const ComponentWithRefOnDomElement = defineComponent({
+      template: '<div ref="hello">Hello!</div>'
+    })
+    const wrapper = mount(ComponentWithRefOnDomElement)
+
+    expect(wrapper.findComponent({ ref: 'hello' }).exists()).toBe(false)
   })
 
   it('finds component by dom selector', () => {


### PR DESCRIPTION
This is first part of fix related to #716 

After certain consideration, I've decided that expected behavior should be not throwing error, but returning empty wrapper instead.
My reasoning is based on three points:

1. Passing `ref` to `findComponent` is perfectly valid syntax. So if we're looking for component with specific ref and it does not exists - why should we complain about HTML element with same ref? We simply should not care
2. (Real world example from gitlab codebase). Consider having `<component ref="hello" :is="foo">` where `foo` under certain conditions is resolved either to `<div>` or to component (let's say `<Note>`). Consider having table syntax test, where we pass certain props... and if we throw, it definitely will look ugly and wrong instead of just checking for `.exists()`
3. `findComponent` does not have `throw` behavior and I'm resisting adding one (keeping mental mode simple - `getComponent` throws, `findComponent` - does not thow)
