### PR TITLE
fix(compat): avoid warning about non-existing export, fix #765

### DIFF
--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -15,13 +15,9 @@ export function isLegacyExtendedComponent(component: unknown): component is {
     return false
   }
 
-  // @ts-ignore Vue.extend is part of Vue2 compat API, types are missing
-  const fakeCmp = Vue.extend({})
-
   return (
     hasOwnProperty(component, 'super') &&
-    hasOwnProperty(component, 'options') &&
-    fakeCmp.super === component.super
+    (component.super as any).extend({}).super === component.super
   )
 }
 


### PR DESCRIPTION
Original issue: #765 

Basically bundlers are too smart and produce a warning about missing export when they see the line:
```js
const fakeCmp = Vue.extend({})
```
**somewhere** in code even if actual execution of this line is guarded (by checking `GLOBAL_COMPAT` flag)

We now use alternate approach for "reaching" `Vue.extend` which does not trigger this warning