### PR TITLE
docs: Add learning links

### DIFF
--- a/docs/guide/extending-vtu/community-learning.md
+++ b/docs/guide/extending-vtu/community-learning.md
@@ -1,7 +1,7 @@
 # Community and Learning
 
-Links to a future plugin repository
-
-Links to vue testing lib
-
-Links to other resources?
+- [Vue 3 Testing Handbook](https://lmiller1990.github.io/vue-testing-handbook/v3/). Online guide.
+- [Vue.js 3: The Composition API](https://vuejs-course.com/composition-api). Online course (includes a testing module).
+- [Testing Vue 3 apps with Vue Test Utils](https://www.youtube.com/playlist?list=PLC2LZCNWKL9ahK1IoODqYxKu5aA9T5IOA). Playlist.
+- [Testing Vue.js Components](https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vth). Online course.
+- [Front-end Testing and a tale of three users](https://afontcu.dev/frontend-testing-code-consumers/). Blog post.


### PR DESCRIPTION
This could be greatly improved in both quality and quantity, but just thought that it's better than having an empty page.