### PR TITLE
fix(findComponent): return root instance if it matches

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -164,17 +164,17 @@ export class VueWrapper<T extends ComponentPublicInstance>
       }
     }
 
-    const result = find(this.vm.$.subTree, selector)
-    if (result.length) {
-      return createWrapper(null, result[0])
-    }
-
     // https://github.com/vuejs/vue-test-utils-next/issues/211
     // VTU v1 supported finding the component mounted itself.
     // eg: mount(Comp).findComponent(Comp)
     // this is the same as doing `wrapper.vm`, but we keep this behavior for back compat.
     if (matches(this.vm.$.vnode, selector)) {
       return createWrapper(null, this.vm.$.vnode.component?.proxy!)
+    }
+
+    const result = find(this.vm.$.subTree, selector)
+    if (result.length) {
+      return createWrapper(null, result[0])
     }
 
     return createWrapperError('VueWrapper')

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -67,15 +67,6 @@ describe('findComponent', () => {
     )
   })
 
-  it('finds a component when root of mounted component', async () => {
-    const wrapper = mount(compD)
-    // make sure it finds the component, not its root
-    expect(wrapper.findComponent('.c-as-root-on-d').vm).toHaveProperty(
-      '$options.name',
-      'ComponentC'
-    )
-  })
-
   it('finds component by name', () => {
     const wrapper = mount(compA)
     expect(wrapper.findComponent({ name: 'Hello' }).text()).toBe('Hello world')
@@ -98,6 +89,19 @@ describe('findComponent', () => {
     expect(wrapper.findComponent(Comp).exists()).toBe(true)
     await wrapper.find('input').setValue('bar')
     expect(wrapper.html()).toContain('bar')
+  })
+
+  it('finds root component when recursion is used', async () => {
+    const Comp = defineComponent({
+      props: ['depth'],
+      name: 'Comp',
+      template: `
+        <Comp :depth="depth + 1" v-if="depth < 2" />
+        Depth {{ depth }}
+      `
+    })
+    const wrapper = mount(Comp, { props: { depth: 0 } })
+    expect(wrapper.findComponent(Comp).props('depth')).toBe(0)
   })
 
   it('finds component without a name by using its object definition', () => {


### PR DESCRIPTION
When we're using `findComponent` on recursive component, the result is pretty unexpected - if our selector matches root - it will return first nested instance. Considering #211 I've made sure that if root matches - it always takes priority

This resulted in failing test which literally expects other behavior. After some consideration and verifying this is behavior of vue-test-utils v1 [CodeSandBox](https://codesandbox.io/s/charming-framework-qzilk?file=/src/App.test.js:276-327) - I've dropped offending test intentionally (@dobromir-hristov will be cool if you could look and approve that)