### PR TITLE
chore(find): simplify vnode traversal

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -127,11 +127,8 @@ function findAllVNodes(
   const nodes: VNode[] = [vnode]
   while (nodes.length) {
     const node = nodes.shift()!
-    // match direct children
     aggregateChildren(nodes, node.children)
     if (node.component) {
-      // match children of the wrapping component
-      aggregateChildren(nodes, node.component.subTree.children)
       aggregateChildren(nodes, [node.component.subTree])
     }
     if (node.suspense) {
@@ -139,7 +136,7 @@ function findAllVNodes(
       const { activeBranch } = node.suspense
       aggregateChildren(nodes, [activeBranch])
     }
-    if (matches(node, selector) && !matchingNodes.includes(node)) {
+    if (matches(node, selector)) {
       matchingNodes.push(node)
     }
   }


### PR DESCRIPTION
Basically, this is a proper finisher for #188 - we can avoid going over same vnodes again and again if we do not queue them multiple times - as long as we queue `node.component.subTree` - no need to queue`subTree.children` - they will be aggregated later by calling `aggregateChildren(nodes, node.children)`


@lmiller1990 I think you will be happy to see we're finally simplifying this part a bit :)