### PR TITLE
docs: match findAll example template and test

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1062,7 +1062,7 @@ test('findAll', () => {
   const wrapper = mount(BaseTable);
 
   // .findAll() returns an array of DOMWrappers
-  const thirdRow = wrapper.findAll('tr')[2];
+  const thirdRow = wrapper.findAll('span')[2];
 })
 ```
 


### PR DESCRIPTION
findAll example test looks for <tr> elements but <span> elements are used inside template