### PR TITLE
fix(slots): does not expose extra wrapper of slot content, fix #389

### DIFF
--- a/tests/mountingOptions/slots.spec.ts
+++ b/tests/mountingOptions/slots.spec.ts
@@ -262,4 +262,15 @@ describe('slots', () => {
     expect(parentMounted).toHaveBeenCalled()
     expect(childMounted).toHaveBeenCalled()
   })
+
+  it('should return the correct number of vnodes in the slots', () => {
+    const wrapper = mount(ComponentWithSlots, {
+      slots: {
+        default: '<div/><div/>'
+      }
+    })
+
+    // @ts-expect-error
+    expect(wrapper.vm.$slots.default()).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
Exposing extra "SlotWrapper" in certain cases makes VTU behavior different from browser one, as mentioned in #389 

This PR gets rid of "exposing" anything wrapping slot, by providing same function, as if slot was passed in template

~~This PR depends on #815 so it is marked as draft for now :)
Changes specific to this PR could be viewed at d3a147c~~