### PR TITLE
Fix typo in get method description

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1222,7 +1222,7 @@ test('findAllComponents', () => {
 
 ### get
 
-Gets an an element and returns a `DOMWrapper` if found. Otherwise it throws an error.
+Gets an element and returns a `DOMWrapper` if found. Otherwise it throws an error.
 
 **Signature:**
 


### PR DESCRIPTION
Fixed a typo in the `get` method description

## Before

Gets **an an** element and returns a `DOMWrapper` if found. Otherwise it throws an error.

## After

Gets **an** element and returns a `DOMWrapper` if found. Otherwise it throws an error.