### PR TITLE
docs: fix test in making http requests

### DIFF
--- a/docs/guide/advanced/http-requests.md
+++ b/docs/guide/advanced/http-requests.md
@@ -51,15 +51,15 @@ import { mount, flushPromises } from '@vue/test-utils'
 import axios from 'axios'
 import PostList from './PostList.vue'
 
-const fakePostList = [
+const mockPostList = [
   { id: 1, title: 'title1' },
   { id: 2, title: 'title2' }
 ]
 
 // Following lines tell Jest to mock any call to `axios.get`
-// and to return `fakePostList` instead
+// and to return `mockPostList` instead
 jest.mock('axios', () => ({
-  get: jest.fn(() => fakePostList)
+  get: jest.fn(() => mockPostList)
 }))
 
 test('loads posts on button click', async () => {
@@ -84,7 +84,10 @@ test('loads posts on button click', async () => {
 })
 ```
 
-Notice how we awaited `flushPromises` and then interacted with the Component. We do so to ensure that the DOM has been updated before the assertions run.
+Pay attention that we added prefix `mock` to the variable `mockPostList`. If not, we will get the error: "The module factory of jest.mock() is not allowed to reference any out-of-scope variables."
+Additional info is located here: https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter.
+
+Also notice how we awaited `flushPromises` and then interacted with the Component. We do so to ensure that the DOM has been updated before the assertions run.
 
 :::tip Alternatives to jest.mock()
 There are several ways of setting mocks in Jest. The one used in the example above is the simplest. For more powerful alternatives, you might want to check out [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter) or [msw](https://github.com/mswjs/msw), among others.

--- a/docs/guide/advanced/http-requests.md
+++ b/docs/guide/advanced/http-requests.md
@@ -84,8 +84,7 @@ test('loads posts on button click', async () => {
 })
 ```
 
-Pay attention that we added prefix `mock` to the variable `mockPostList`. If not, we will get the error: "The module factory of jest.mock() is not allowed to reference any out-of-scope variables."
-Additional info is located here: https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter.
+Pay attention that we added prefix `mock` to the variable `mockPostList`. If not, we will get the error: "The module factory of jest.mock() is not allowed to reference any out-of-scope variables.". This is jest-specific, and you can read more about this behavior [in their docs](https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter).
 
 Also notice how we awaited `flushPromises` and then interacted with the Component. We do so to ensure that the DOM has been updated before the assertions run.
 


### PR DESCRIPTION
This PR fixes the test in the section "Making HTTP Requests" (https://next.vue-test-utils.vuejs.org/guide/advanced/http-requests.html) and makes some explain.

**Why it is necessary?**

Because it has been mentioned in #868.

The previous test is broken because you cannot access variables/methods unprefixed with `mock`. Follow this: https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter.

> A limitation with the factory parameter is that, since calls to jest.mock() are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.