### PR TITLE
feat(find): allow chaining find with findComponent

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -132,22 +132,6 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return createWrapperError('DOMWrapper')
   }
 
-  get<K extends keyof HTMLElementTagNameMap>(
-    selector: K
-  ): Omit<DOMWrapper<HTMLElementTagNameMap[K]>, 'exists'>
-  get<K extends keyof SVGElementTagNameMap>(
-    selector: K
-  ): Omit<DOMWrapper<SVGElementTagNameMap[K]>, 'exists'>
-  get<T extends Element>(selector: string): Omit<DOMWrapper<T>, 'exists'>
-  get(selector: string): Omit<DOMWrapper<Element>, 'exists'> {
-    const result = this.find(selector)
-    if (result instanceof DOMWrapper) {
-      return result
-    }
-
-    throw new Error(`Unable to get ${selector} within: ${this.html()}`)
-  }
-
   findComponent<T extends ComponentPublicInstance>(
     selector: FindComponentSelector | (new () => T)
   ): VueWrapper<T> {
@@ -182,30 +166,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
     return createWrapperError('VueWrapper')
   }
 
-  getComponent<T extends ComponentPublicInstance>(
-    selector: FindComponentSelector | (new () => T)
-  ): Omit<VueWrapper<T>, 'exists'> {
-    const result = this.findComponent(selector)
-
-    if (result instanceof VueWrapper) {
-      return result as VueWrapper<T>
-    }
-
-    let message = 'Unable to get '
-    if (typeof selector === 'string') {
-      message += `component with selector ${selector}`
-    } else if ('name' in selector) {
-      message += `component with name ${selector.name}`
-    } else if ('ref' in selector) {
-      message += `component with ref ${selector.ref}`
-    } else {
-      message += 'specified component'
-    }
-    message += ` within: ${this.html()}`
-    throw new Error(message)
-  }
-
-  findAllComponents(selector: FindAllComponentsSelector): VueWrapper<T>[] {
+  findAllComponents(selector: FindAllComponentsSelector): VueWrapper<any>[] {
     if (typeof selector === 'string') {
       throw Error(
         'findAllComponents requires a Vue constructor or valid find object. If you are searching for DOM nodes, use `find` instead'

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -24,4 +24,15 @@ describe('findAllComponents', () => {
     )
     expect(wrapper.findAllComponents(Hello)[0].text()).toBe('Hello world')
   })
+
+  it('finds all deeply nested vue components when chained from dom wrapper', () => {
+    const Component = defineComponent({
+      components: { Hello },
+      template:
+        '<div><Hello /><div class="nested"><Hello /><Hello /></div></div>'
+    })
+    const wrapper = mount(Component)
+    expect(wrapper.findAllComponents(Hello)).toHaveLength(3)
+    expect(wrapper.find('.nested').findAllComponents(Hello)).toHaveLength(2)
+  })
 })

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -347,4 +347,73 @@ describe('findComponent', () => {
     })
     expect(wrapper.findComponent(Func).exists()).toBe(true)
   })
+
+  describe('chaining from dom wrapper', () => {
+    it('finds a component nested inside a node', () => {
+      const Comp = defineComponent({
+        components: { Hello: Hello },
+        template: '<div><div class="nested"><Hello /></div></div>'
+      })
+
+      const wrapper = mount(Comp)
+      expect(wrapper.find('.nested').findComponent(Hello).exists()).toBe(true)
+    })
+
+    it('finds a component inside DOM node', () => {
+      const Comp = defineComponent({
+        components: { Hello: Hello },
+        template:
+          '<div><Hello class="one"/><div class="nested"><Hello class="two" /></div>'
+      })
+
+      const wrapper = mount(Comp)
+      expect(wrapper.find('.nested').findComponent(Hello).classes('two')).toBe(
+        true
+      )
+    })
+
+    it('returns correct instance of recursive component', () => {
+      const Comp = defineComponent({
+        name: 'Comp',
+        props: ['firstLevel'],
+        template:
+          '<div class="first"><div class="nested"><Comp v-if="firstLevel" class="second" /></div>'
+      })
+
+      const wrapper = mount(Comp, { props: { firstLevel: true } })
+      expect(
+        wrapper.find('.nested').findComponent(Comp).classes('second')
+      ).toBe(true)
+    })
+
+    it('returns top-level component if it matches', () => {
+      const Comp = defineComponent({
+        name: 'Comp',
+        template: '<div class="top"></div>'
+      })
+
+      const wrapper = mount(Comp)
+      expect(wrapper.find('.top').findComponent(Comp).classes('top')).toBe(true)
+    })
+
+    it('uses refs of correct component when searching by ref', () => {
+      const Child = defineComponent({
+        components: { Hello },
+        template: '<div><Hello ref="testRef" class="inside"></div>'
+      })
+      const Comp = defineComponent({
+        components: { Child, Hello },
+        template:
+          '<div><Child class="nested" /><Hello ref="testRef" class="outside" /></div>'
+      })
+
+      const wrapper = mount(Comp)
+      expect(
+        wrapper
+          .find('.nested')
+          .findComponent({ ref: 'testRef' })
+          .classes('inside')
+      ).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
This is a follow-up (lol) of https://github.com/vuejs/vue-test-utils/issues/1703#issuecomment-707134340

Chaining `.find` with `.findComponent` has multiple usages in GitLab and other projects (for example `bootstrap-vue`) (see https://github.com/vuejs/vue-test-utils/issues/1703#issuecomment-707085682) and actually was a blocker for us to move our API from `find` to `findComponent` in VTU v1 :)

This PR adds chaining to VTU v2. Additionally it enables "workaround" if someone **urgently** need to find some known component by CSS selector as mentioned in #689 (assuming #896 is merged): 
```js
wrapper.find('.foo').findComponent(Hello)
```
will match `<Hello class="foo" />`. I like both that we have possibility to do that if really needed (for example for gradual migration) and that it looks & feels ugly so people with high probability will stop and re-think their approach