### PR TITLE
docs: vue-router composition api example

### DIFF
--- a/docs/guide/advanced/vue-router.md
+++ b/docs/guide/advanced/vue-router.md
@@ -338,7 +338,7 @@ This time in order to test the component, we will use jest's ability to mock an 
 import { useRouter, useRoute } from 'vue-router'
 
 jest.mock('vue-router', () => ({
-  useRoute: jest.fn(() => ({ })),
+  useRoute: jest.fn(),
   useRouter: jest.fn(() => ({
     push: () => {}
   }))
@@ -397,6 +397,8 @@ test('redirect an unauthenticated user to 404', () => {
   expect(push).toHaveBeenCalledWith('/404')
 })
 ```
+
+For those who prefer a non-manual approach, the library [vue-router-mock](https://github.com/posva/vue-router-mock) created by Posva is also available as an alternative.
 
 ## Conclusion
 


### PR DESCRIPTION
Adds examples on how to mock vue-router 4 when using `useRouter` and `useRoute` on a setup function through composition API.