### PR TITLE
chore: fix build warning

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -30,7 +30,7 @@ export function emitted<T = unknown>(
 export const attachEmitListener = () => {
   events = {}
   // use devtools to capture this "emit"
-  setDevtoolsHook(createDevTools(events), this)
+  setDevtoolsHook(createDevTools(events), {})
 }
 
 // devtools hook only catches Vue component custom events


### PR DESCRIPTION
Rollup was complaining about:
```
(!) `this` has been rewritten to `undefined`
https://rollupjs.org/guide/en/#error-this-is-undefined
src/emit.ts
1: var _this = this;
               ^
2: import { setDevtoolsHook } from 'vue';
3: var events;
```

This commit gets rid of the warning by using `{}` instead of `this` for `setDevtoolsHook` second parameter.
`vue-next` uses `getGlobalThis()` as the second parameter, which ultimately falls back to `{}`.