### PR TITLE
Add missing brackets in useRouter example

### DIFF
--- a/docs/guide/advanced/vue-router.md
+++ b/docs/guide/advanced/vue-router.md
@@ -352,9 +352,9 @@ test('allows authenticated user to edit a post', () => {
   }))
 
   const push = jest.fn()
-  useRouter.mockImplementationOnce(() => {
+  useRouter.mockImplementationOnce(() => ({
     push
-  })
+  }))
 
   const wrapper = mount(Component, {
     props: {
@@ -381,9 +381,9 @@ test('redirect an unauthenticated user to 404', () => {
   }))
 
   const push = jest.fn()
-  useRouter.mockImplementationOnce(() => {
+  useRouter.mockImplementationOnce(() => ({
     push
-  })
+  }))
 
   const wrapper = mount(Component, {
     props: {


### PR DESCRIPTION
Adds missing brackets in "Testing useRouter and useRoute within setup" example and closes https://github.com/vuejs/vue-test-utils-next/issues/1055