### PR TITLE
fix: [BREAKING] Use default name for components with setup script and nameless compon…

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -109,9 +109,14 @@ const getComponentRegisteredName = (
   return null
 }
 
-const getComponentName = (type: VNodeTypes): string => {
+const getComponentName = (
+  instance: any | null,
+  type: VNodeTypes
+): string => {
   if (isObjectComponent(type)) {
-    return type.name || ''
+    const defaultName = Object.keys(instance?.setupState || {}).find((key) => instance.setupState[key] === type)
+
+    return type.name || defaultName || ''
   }
 
   if (isLegacyExtendedComponent(type)) {
@@ -190,7 +195,7 @@ export function stubComponents(
       }
 
       const registeredName = getComponentRegisteredName(instance, type)
-      const componentName = getComponentName(type)
+      const componentName = getComponentName(instance, type)
 
       let stub = null
       let name = null

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -109,12 +109,11 @@ const getComponentRegisteredName = (
   return null
 }
 
-const getComponentName = (
-  instance: any | null,
-  type: VNodeTypes
-): string => {
+const getComponentName = (instance: any | null, type: VNodeTypes): string => {
   if (isObjectComponent(type)) {
-    const defaultName = Object.keys(instance?.setupState || {}).find((key) => instance.setupState[key] === type)
+    const defaultName = Object.keys(instance?.setupState || {}).find(
+      (key) => instance.setupState[key] === type
+    )
 
     return type.name || defaultName || ''
   }

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -160,8 +160,8 @@ describe('shallowMount', () => {
     expect(wrapper.html()).toEqual(
       '<div>Override</div>\n' +
         '<component-with-input-stub></component-with-input-stub>\n' +
-        '<anonymous-stub></anonymous-stub>\n' +
-        '<anonymous-stub></anonymous-stub>\n' +
+        '<component-without-name-stub></component-without-name-stub>\n' +
+        '<script-setup-stub></script-setup-stub>\n' +
         '<with-props-stub></with-props-stub>'
     )
   })


### PR DESCRIPTION
This PR in the following of issue #806 replaces the anonymous naming with the default component name:

So the following component's stub name will be `script-setup-stub`:
```js
//filename: ScriptSetup.vue
<script setup>
...
</script>
```

Also, the same approach works on nameless components.
The test coverage applied for this fix.