### PR TITLE
fix: expose with render function

### DIFF
--- a/tests/components/DefineExposeWithRenderFunction.vue
+++ b/tests/components/DefineExposeWithRenderFunction.vue
@@ -1,0 +1,14 @@
+<script lang="ts">
+import { defineComponent, h, ref } from 'vue'
+
+export default defineComponent({
+  name: 'Hello',
+
+  setup(props, { expose }) {
+    const other = ref('other')
+    const msg = ref('Hello world')
+    expose({ other })
+    return () => [h('div', msg.value), h('div', other.value)]
+  }
+})
+</script>

--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 import DefineExpose from './components/DefineExpose.vue'
+import DefineExposeWithRenderFunction from './components/DefineExposeWithRenderFunction.vue'
 import ScriptSetupExpose from './components/ScriptSetup_Expose.vue'
 import ScriptSetup from './components/ScriptSetup.vue'
 
@@ -18,6 +19,16 @@ describe('expose', () => {
     expect(wrapper.vm.other).toBe('other')
     // can access `msg` even if not exposed
     expect(wrapper.vm.msg).toBe('Hello world')
+  })
+
+  it('access vm on simple components with custom `expose` and a setup returning a render function', async () => {
+    const wrapper = mount(DefineExposeWithRenderFunction)
+
+    // other is exposed vie `expose`
+    expect(wrapper.vm.other).toBe('other')
+    // can't access `msg` as it is not exposed
+    // and we are in a component with a setup returning a render function
+    expect(wrapper.vm.msg).toBeUndefined()
   })
 
   it('access vm with <script setup> and defineExpose()', async () => {


### PR DESCRIPTION
Fixes #1065

When we are testing a component with a render function returned by the setup,
then its proxy will be empty.
The behavior difference can be seen in vue-next [here](https://github.com/vuejs/vue-next/blob/d19cfc0503dddbded5e599bef0965aba3d25ca28/packages/runtime-core/src/component.ts#L674).
In that case, `wrapper.vm` will be empty if we return `vm.$.proxy`.
To handle it, we return `vm` directly for such components,
allowing at least what is exposed publicly to be available on `wrapper.vm`.