### PR TITLE
fix(find): Allow finding self from DOMWrapper

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -34,6 +34,10 @@ export class DOMWrapper<ElementType extends Element>
   ): DOMWrapper<SVGElementTagNameMap[K]>
   find<T extends Element>(selector: string): DOMWrapper<T>
   find(selector: string): DOMWrapper<Element> {
+    // allow finding the root element
+    if (this.element.matches(selector)) {
+      return this
+    }
     const result = this.element.querySelector(selector)
     if (result) {
       return new DOMWrapper(result)

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -39,7 +39,7 @@ describe('find', () => {
           <component-b v-for="item in [1, 2]" :key="item">
             <input type="text" :value="item">
           </component-b>
-        </div> 
+        </div>
       `,
       components: { ComponentB }
     })
@@ -61,6 +61,18 @@ describe('find', () => {
 
     const wrapper = mount(Component)
     expect(wrapper.find('.foo').exists()).toBe(true)
+  })
+
+  it('returns the root element from dom wrapper if it matches', () => {
+    const Component = defineComponent({
+      render() {
+        return h('div', { class: 'foo' }, 'text')
+      }
+    })
+
+    const wrapper = mount(Component)
+    const domWrapper = wrapper.find('.foo')
+    expect(domWrapper.find('.foo').exists()).toBe(true)
   })
 
   it('can be chained', () => {


### PR DESCRIPTION
`@vue/test/utils` v1 returns DOMWrapper itself if it matches selector passed in `find` (this is identical to `findComponent` behavior which was fixed in https://github.com/vuejs/vue-test-utils-next/pull/834)

This is heavily used in (for example) `bootstrap-vue` (ignore legacy `.wrappers` part):
```js
    expect($inputs.wrappers.every(c => c.find('input[type=checkbox]').exists())).toBe(true)
```

Although I'm not 100% happy with such behavior I think we should match v1