### PR TITLE
fix(findComponent): favor displayName over name when searching

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -45,14 +45,16 @@ export function matches(
   }
 
   let componentName: string | undefined
-  if ('name' in nodeType) {
-    // match normal component definitions
-    componentName = nodeType.name
-  }
-  if (!componentName && 'displayName' in nodeType) {
+  if ('displayName' in nodeType) {
     // match functional components
     componentName = nodeType.displayName
   }
+
+  if (!componentName && 'name' in nodeType) {
+    // match normal component definitions
+    componentName = nodeType.name
+  }
+
   let selectorName = selector.name
 
   // the component and selector both have a name

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -412,6 +412,23 @@ describe('findComponent', () => {
       expect(wrapper.find('.top').findComponent(Comp).classes('top')).toBe(true)
     })
 
+    it('finds functional components by component displayName', () => {
+      const cmp = () => h('button', { class: 'some-class ' })
+      cmp.displayName = 'FuncButton'
+      const Comp = defineComponent({
+        components: { ChildComponent: cmp },
+        template: '<div><child-component />Test</button></div>'
+      })
+
+      const wrapper = mount(Comp)
+      expect(wrapper.findAllComponents({ name: cmp.displayName }).length).toBe(
+        1
+      )
+      expect(wrapper.findComponent({ name: cmp.displayName }).exists()).toBe(
+        true
+      )
+    })
+
     it('uses refs of correct component when searching by ref', () => {
       const Child = defineComponent({
         components: { Hello },


### PR DESCRIPTION
This fix swaps priority order when searching for component by name to make `displayName` respected.
It is important for functional components: 
```js
const Cmp = () => 'hello'
// hey, I gave this one a displayName for A REASON
Cmp.displayName = 'FooComponent';
```
but is even more important for legacy functional components when used with `@vue/compat` - every single functional component will be named `Func` without this fix :)