### PR TITLE
fix(mount): pass unknown options to $options on mount

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -50,13 +50,34 @@ import { trackInstance } from './utils/autoUnmount'
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
 
+const MOUNT_OPTIONS: Array<keyof MountingOptions<any>> = [
+  'attachTo',
+  'attrs',
+  'data',
+  'props',
+  'slots',
+  'global',
+  'shallow'
+]
+
+function getInstanceOptions(
+  options: MountingOptions<any> & Record<string, any>
+): Record<string, any> {
+  const resultOptions = { ...options }
+  for (const key of Object.keys(options)) {
+    if (MOUNT_OPTIONS.includes(key as keyof MountingOptions<any>)) {
+      delete resultOptions[key]
+    }
+  }
+  return resultOptions
+}
 // Class component - no props
 export function mount<V>(
   originalComponent: {
     new (...args: any[]): V
     registerHooks(keys: string[]): void
   },
-  options?: MountingOptions<any>
+  options?: MountingOptions<any> & Record<string, any>
 ): VueWrapper<ComponentPublicInstance<V>>
 
 // Class component - props
@@ -66,13 +87,13 @@ export function mount<V, P>(
     props(Props: P): any
     registerHooks(keys: string[]): void
   },
-  options?: MountingOptions<P & PublicProps>
+  options?: MountingOptions<P & PublicProps> & Record<string, any>
 ): VueWrapper<ComponentPublicInstance<V>>
 
 // Functional component with emits
 export function mount<Props, E extends EmitsOptions = {}>(
   originalComponent: FunctionalComponent<Props, E>,
-  options?: MountingOptions<Props & PublicProps>
+  options?: MountingOptions<Props & PublicProps> & Record<string, any>
 ): VueWrapper<ComponentPublicInstance<Props>>
 
 // Component declared with defineComponent
@@ -107,7 +128,8 @@ export function mount<
   options?: MountingOptions<
     Partial<Defaults> & Omit<Props & PublicProps, keyof Defaults>,
     D
-  >
+  > &
+    Record<string, any>
 ): VueWrapper<
   InstanceType<
     DefineComponent<
@@ -153,7 +175,8 @@ export function mount<
   options?: MountingOptions<Props & PublicProps, D>
 ): VueWrapper<
   ComponentPublicInstance<Props, RawBindings, D, C, M, E, VNodeProps & Props>
->
+> &
+  Record<string, any>
 
 // Component declared with { props: [] }
 export function mount<
@@ -226,11 +249,12 @@ export function mount<
 // implementation
 export function mount(
   inputComponent: any,
-  options?: MountingOptions<any>
+  options?: MountingOptions<any> & Record<string, any>
 ): VueWrapper<any> {
   // normalise the incoming component
   let originalComponent = unwrapLegacyVueExtendComponent(inputComponent)
   let component: ConcreteComponent
+  const instanceOptions = getInstanceOptions(options ?? {})
 
   if (
     isFunctionalComponent(originalComponent) ||
@@ -240,11 +264,12 @@ export function mount(
       setup:
         (_, { attrs, slots }) =>
         () =>
-          h(originalComponent, attrs, slots)
+          h(originalComponent, attrs, slots),
+      ...instanceOptions
     })
     addToDoNotStubComponents(originalComponent)
   } else if (isObjectComponent(originalComponent)) {
-    component = { ...originalComponent }
+    component = { ...originalComponent, ...instanceOptions }
   } else {
     component = originalComponent
   }

--- a/tests/mountingOptions/options.spec.ts
+++ b/tests/mountingOptions/options.spec.ts
@@ -1,0 +1,13 @@
+import { defineComponent } from 'vue'
+import { mount } from '../../src'
+
+describe('mounting options: other', () => {
+  it('passes other options as $options to component', () => {
+    const TestComponent = defineComponent({ template: '<div>test</div>' })
+    const optionContent = {}
+    const wrapper = mount(TestComponent, {
+      someUnknownOption: optionContent
+    })
+    expect(wrapper.vm.$options.someUnknownOption).toBe(optionContent)
+  })
+})


### PR DESCRIPTION
Vue 3.x keeps the behaviour we've had in Vue2: all unknown fields in component are passed as $options. This allows you to do following:
```
createApp({ ...App, test: 123 }).mount("#app");
```
and access test on `this.$options.test`
While not in a great use in modern Vue 3 code, this is still a great importance when we work with `@vue/compat` - you are still want to be able to pass router/store/etc. in "legacy" way to your component

This PR restores this behavior