### PR TITLE
fix(compat): handle listener, style and class in legacy functional components

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -237,6 +237,11 @@ export function mount(
     isLegacyFunctionalComponent(originalComponent)
   ) {
     component = defineComponent({
+      compatConfig: {
+        MODE: 3,
+        INSTANCE_LISTENERS: false,
+        INSTANCE_ATTRS_CLASS_STYLE: false
+      },
       setup:
         (_, { attrs, slots }) =>
         () =>

--- a/src/utils/vueCompatSupport.ts
+++ b/src/utils/vueCompatSupport.ts
@@ -32,10 +32,10 @@ export function isLegacyFunctionalComponent(component: unknown) {
     return false
   }
 
-  return (
+  return Boolean(
     component &&
-    typeof component === 'object' &&
-    hasOwnProperty(component, 'functional') &&
-    component.functional
+      typeof component === 'object' &&
+      hasOwnProperty(component, 'functional') &&
+      component.functional
   )
 }

--- a/tests-compat/compat.spec.ts
+++ b/tests-compat/compat.spec.ts
@@ -143,4 +143,35 @@ describe('@vue/compat build', () => {
 
     expect(wrapper.vm.foo).toBe('bar')
   })
+
+  it('correctly passes all props to functional component', async () => {
+    configureCompat({
+      MODE: 3,
+      INSTANCE_LISTENERS: 'suppress-warning',
+      INSTANCE_ATTRS_CLASS_STYLE: 'suppress-warning'
+    })
+
+    const FunctionalComponent = {
+      functional: true,
+      render(h: any, context: any) {
+        return h('div', context.data, context.props.text)
+      }
+    }
+
+    const onClick = jest.fn()
+    const wrapper = mount(FunctionalComponent, {
+      props: {
+        class: 'foo',
+        text: 'message',
+        style: { color: 'red' },
+        onClick
+      }
+    })
+    expect(wrapper.text()).toBe('message')
+    await wrapper.trigger('click')
+    expect(onClick).toHaveBeenCalled()
+    expect(wrapper.html()).toBe(
+      '<div class="foo" text="message" style="color: red;">message</div>'
+    )
+  })
 })


### PR DESCRIPTION
This one was quite tricky to debug :clock10: 

Basically, when dealing with legacy functional component we need to enable `FUNCTIONAL_COMPONENT` compatibility flag for `@vue/compat`

The problem is that we're wrapping this component inside `mount.ts` into script-setup component, which triggers Vue to render this component in "Vue 3 mode". ~~Usually this is not a problem - each component controls own compat flags using `compatConfig` but this is not a case for functional components - they do not have own instance, and compat config calculation is instance-based. This resulted into wrong normalization applied insid `@vue/compat` and result component simply ignoring event handlers inside test. To fix this we explicitly set `FUNCTIONAL_COMPONENT` flag in our "wrapper component" so Vue could correctly handle this~~

Original explanation was wrong, now I figured root cause of the issue. When `INSTANCE_LISTENERS` or `INSTANCE_ATTRS_CLASS_STYLE` is set - Vue is [slicing](https://github.com/vuejs/vue-next/blob/4178d5d7d9549a0a1d19663bc2f92c8ac6a731b2/packages/runtime-core/src/compat/attrsFallthrough.ts#L5-L29) "props" to props/listeners/attrs combination. The problem is that `script setup` simply has no way of accessing `listeners` (for example) if this compat flag is enabled so they are just lost. In order to mitigate this we explicitly set two flags mentioned in `atrrsFallthrough.ts` to `false` for our component making sure they will be passed to our component under test in proper way

