### PR TITLE
fix: remove symbol props from stubs

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -22,7 +22,7 @@ import { Stub, Stubs } from './types'
 
 interface StubOptions {
   name: string
-  propsDeclaration: ComponentPropsOptions
+  propsDeclaration?: ComponentPropsOptions
   renderStubDefaultSlot?: boolean
 }
 
@@ -43,7 +43,7 @@ const shouldNotStub = (type: ConcreteComponent) => doNotStubComponents.has(type)
 export const addToDoNotStubComponents = (type: ConcreteComponent) =>
   doNotStubComponents.add(type)
 
-const removeSymbols = <T = ComponentPropsOptions>(props: T): T => {
+const stringifySymbols = (props: ComponentPropsOptions) => {
   // props are always normalized to object syntax
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
@@ -51,7 +51,7 @@ const removeSymbols = <T = ComponentPropsOptions>(props: T): T => {
       return { ...acc, [key]: $props[key]?.toString() }
     }
     return { ...acc, [key]: $props[key] }
-  }, {}) as T
+  }, {})
 }
 
 export const createStub = ({
@@ -68,8 +68,8 @@ export const createStub = ({
     // something like `el.setAttribute('val', Symbol())` which is not valid and
     // causes an error.
     // Only a problem when shallow mounting. For this reason we iterate of the
-    // props that will be passed and remove any that are symbols.
-    const propsWithoutSymbols = removeSymbols(ctx.$props)
+    // props that will be passed and stringify any that are symbols.
+    const propsWithoutSymbols = stringifySymbols(ctx.$props)
 
     return h(
       tag,
@@ -189,7 +189,6 @@ export function stubComponents(
       return [
         createTransitionStub({
           name: 'transition-stub',
-          propsDeclaration: {}
         }),
         undefined,
         children
@@ -205,7 +204,6 @@ export function stubComponents(
       return [
         createTransitionStub({
           name: 'transition-group-stub',
-          propsDeclaration: {}
         }),
         undefined,
         children

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -43,14 +43,14 @@ const shouldNotStub = (type: ConcreteComponent) => doNotStubComponents.has(type)
 export const addToDoNotStubComponents = (type: ConcreteComponent) =>
   doNotStubComponents.add(type)
 
-const removeSymbols = <T = ComponentPropsOptions>(props: T): T  => {
+const removeSymbols = <T = ComponentPropsOptions>(props: T): T => {
   // props are always normalized to object syntax
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
     if (typeof $props[key] === 'symbol') {
       return acc
     }
-    return {...acc, [key]: $props[key]}
+    return { ...acc, [key]: $props[key] }
   }, {}) as T
 }
 
@@ -71,7 +71,11 @@ export const createStub = ({
     // props that will be passed and remove any that are symbols.
     const propsWithoutSymbols = removeSymbols(ctx.$props)
 
-    return h(tag, propsWithoutSymbols, renderStubDefaultSlot ? ctx.$slots : undefined)
+    return h(
+      tag,
+      propsWithoutSymbols,
+      renderStubDefaultSlot ? ctx.$slots : undefined
+    )
   }
 
   return defineComponent({

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -48,7 +48,7 @@ const removeSymbols = <T = ComponentPropsOptions>(props: T): T => {
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
     if (typeof $props[key] === 'symbol') {
-      return {...acc, [key]: $props[key]?.toString()}
+      return { ...acc, [key]: $props[key]?.toString() }
     }
     return { ...acc, [key]: $props[key] }
   }, {}) as T

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -48,7 +48,7 @@ const removeSymbols = <T = ComponentPropsOptions>(props: T): T => {
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
     if (typeof $props[key] === 'symbol') {
-      return acc
+      return {...acc, [key]: $props[key]?.toString()}
     }
     return { ...acc, [key]: $props[key] }
   }, {}) as T
@@ -86,7 +86,7 @@ export const createStub = ({
   })
 }
 
-const createTransitionStub = ({ name, propsDeclaration }: StubOptions) => {
+const createTransitionStub = ({ name }: StubOptions) => {
   const render = (ctx: ComponentPublicInstance) => {
     return h(name, {}, ctx.$slots)
   }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -188,7 +188,7 @@ export function stubComponents(
     if (type === Transition && 'transition' in stubs && stubs['transition']) {
       return [
         createTransitionStub({
-          name: 'transition-stub',
+          name: 'transition-stub'
         }),
         undefined,
         children
@@ -203,7 +203,7 @@ export function stubComponents(
     ) {
       return [
         createTransitionStub({
-          name: 'transition-group-stub',
+          name: 'transition-group-stub'
         }),
         undefined,
         children

--- a/tests/components/PropWithSymbol.vue
+++ b/tests/components/PropWithSymbol.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>Symbol: {{$props.sym}}</div>
+  <div>Symbol: {{ $props.sym }}</div>
 </template>
 
 <script lang="ts" setup>

--- a/tests/components/PropWithSymbol.vue
+++ b/tests/components/PropWithSymbol.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>Symbol: {{$props.sym}}</div>
+</template>
+
+<script lang="ts" setup>
+interface Props {
+  sym?: Symbol
+}
+
+withDefaults(defineProps<Props>(), {
+  sym: () => Symbol()
+})
+</script>

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '../src'
 import WithProps from './components/WithProps.vue'
+import PropWithSymbol from './components/PropWithSymbol.vue'
 import Hello from './components/Hello.vue'
 import { defineComponent, h } from 'vue'
 
@@ -223,5 +224,27 @@ describe('props', () => {
     await wrapper.trigger('click')
 
     expect(wrapper.text()).toEqual('hello')
+  })
+
+  it('works with Symbol as default', () => {
+    const Comp = defineComponent({
+      template: `<div>Symbol: {{ sym }}</div>`,
+      props: {
+        sym: {
+          type: Symbol,
+          default: () => Symbol()
+        }
+      }
+    })
+
+    const wrapper = mount(Comp, { shallow: true })
+
+    expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
+  })
+
+  it('works with Symbol as default from SFC', () => {
+    const wrapper = mount(PropWithSymbol, { shallow: true })
+
+    expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
   })
 })

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -254,6 +254,6 @@ describe('props', () => {
     })
     const wrapper = shallowMount(App)
 
-    expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
+    expect(wrapper.html()).toBe('<prop-with-symbol-stub></prop-with-symbol-stub>')
   })
 })

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -243,7 +243,7 @@ describe('props', () => {
       expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
     })
 
-    it('works with Symbol an array syntax', () => {
+    it('works with symbol as array syntax', () => {
       const Comp = defineComponent({
         name: 'Comp',
         template: `<div>Symbol: {{ sym }}</div>`,
@@ -256,7 +256,7 @@ describe('props', () => {
         }
       })
 
-      expect(wrapper.html()).toBe('<comp-stub></comp-stub>')
+      expect(wrapper.html()).toBe('<comp-stub sym="Symbol()"></comp-stub>')
     })
 
     it('works with symbol as default from SFC', () => {
@@ -272,7 +272,7 @@ describe('props', () => {
       const wrapper = shallowMount(App)
 
       expect(wrapper.html()).toBe(
-        '<prop-with-symbol-stub></prop-with-symbol-stub>'
+        '<prop-with-symbol-stub sym="Symbol()"></prop-with-symbol-stub>'
       )
     })
   })

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -251,7 +251,7 @@ describe('props', () => {
       })
 
       const wrapper = shallowMount({
-        render () {
+        render() {
           return h(Comp, { sym: Symbol() })
         }
       })
@@ -271,7 +271,9 @@ describe('props', () => {
       })
       const wrapper = shallowMount(App)
 
-      expect(wrapper.html()).toBe('<prop-with-symbol-stub></prop-with-symbol-stub>')
+      expect(wrapper.html()).toBe(
+        '<prop-with-symbol-stub></prop-with-symbol-stub>'
+      )
     })
   })
 })

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '../src'
+import { mount, shallowMount } from '../src'
 import WithProps from './components/WithProps.vue'
 import PropWithSymbol from './components/PropWithSymbol.vue'
 import Hello from './components/Hello.vue'
@@ -237,13 +237,22 @@ describe('props', () => {
       }
     })
 
-    const wrapper = mount(Comp, { shallow: true })
+    const wrapper = shallowMount(Comp)
 
     expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
   })
 
-  it('works with Symbol as default from SFC', () => {
-    const wrapper = mount(PropWithSymbol, { shallow: true })
+  it.only('works with symbol as default from SFC', () => {
+    const App = defineComponent({
+      template: `<PropWithSymbol :sym="sym" />`,
+      components: { PropWithSymbol },
+      data() {
+        return {
+          sym: Symbol()
+        }
+      }
+    })
+    const wrapper = shallowMount(App)
 
     expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
   })

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -226,34 +226,52 @@ describe('props', () => {
     expect(wrapper.text()).toEqual('hello')
   })
 
-  it('works with Symbol as default', () => {
-    const Comp = defineComponent({
-      template: `<div>Symbol: {{ sym }}</div>`,
-      props: {
-        sym: {
-          type: Symbol,
-          default: () => Symbol()
+  describe('edge case with symbol props and stubs', () => {
+    it('works with Symbol as default', () => {
+      const Comp = defineComponent({
+        template: `<div>Symbol: {{ sym }}</div>`,
+        props: {
+          sym: {
+            type: Symbol,
+            default: () => Symbol()
+          }
         }
-      }
+      })
+
+      const wrapper = shallowMount(Comp)
+
+      expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
     })
 
-    const wrapper = shallowMount(Comp)
+    it('works with Symbol an array syntax', () => {
+      const Comp = defineComponent({
+        name: 'Comp',
+        template: `<div>Symbol: {{ sym }}</div>`,
+        props: ['sym']
+      })
 
-    expect(wrapper.html()).toBe('<div>Symbol: Symbol()</div>')
-  })
-
-  it.only('works with symbol as default from SFC', () => {
-    const App = defineComponent({
-      template: `<PropWithSymbol :sym="sym" />`,
-      components: { PropWithSymbol },
-      data() {
-        return {
-          sym: Symbol()
+      const wrapper = shallowMount({
+        render () {
+          return h(Comp, { sym: Symbol() })
         }
-      }
-    })
-    const wrapper = shallowMount(App)
+      })
 
-    expect(wrapper.html()).toBe('<prop-with-symbol-stub></prop-with-symbol-stub>')
+      expect(wrapper.html()).toBe('<comp-stub></comp-stub>')
+    })
+
+    it('works with symbol as default from SFC', () => {
+      const App = defineComponent({
+        template: `<PropWithSymbol :sym="sym" />`,
+        components: { PropWithSymbol },
+        data() {
+          return {
+            sym: Symbol()
+          }
+        }
+      })
+      const wrapper = shallowMount(App)
+
+      expect(wrapper.html()).toBe('<prop-with-symbol-stub></prop-with-symbol-stub>')
+    })
   })
 })


### PR DESCRIPTION
resolves #1076

More context: https://github.com/ionic-team/ionic-framework/issues/24181

Basically when you do a stub that receives a `Symbol` as a prop, it ends up doing `<blah-stub sym="Symbol()">` which isn't allowed. Try it in your browser: `document.body.setAttribute('sym', Symbol())`.

I just filter out all the symbol props. Bit of a hack, but not a breaking change (passing a symbol as prop to a stub causes an error in both VTU v1 and v2). 

Happy to solicit any better work arounds for this issue, best I could come up with for now to unblock the issue in Ionic team repo.