### PR TITLE
feat: add ability to stub teleport

### DIFF
--- a/docs/guide/advanced/teleport.md
+++ b/docs/guide/advanced/teleport.md
@@ -4,6 +4,10 @@ Vue 3 comes with a new built-in component: `<Teleport>`, which allows components
 
 Here are some strategies and techniques for testing components using `<Teleport>`.
 
+::: tip
+If you want to test the rest of your component, ignoring teleport, you can stub `teleport` by passing `teleport: true` in the [global stubs option](../../api/#global-stubs).
+:::
+
 ## Example
 
 In this example we are testing a `<Navbar>` component. It renders a `<Signup>` component inside of a `<Teleport>`. The `target` prop of `<Teleport>` is an element located outside of the `<Navbar>` component.

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ export const config: GlobalConfigOptions = {
   global: {
     stubs: {
       transition: true,
-      'transition-group': true,
+      'transition-group': true
     },
     provide: {},
     components: {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,8 @@ export const config: GlobalConfigOptions = {
   global: {
     stubs: {
       transition: true,
-      'transition-group': true
+      'transition-group': true,
+      teleport: true,
     },
     provide: {},
     components: {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,6 @@ export const config: GlobalConfigOptions = {
     stubs: {
       transition: true,
       'transition-group': true,
-      teleport: true,
     },
     provide: {},
     components: {},

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -171,7 +171,7 @@ export function stubComponents(
 
   transformVNodeArgs((args, instance: ComponentInternalInstance | null) => {
     const [nodeType, props, children, patchFlag, dynamicProps] = args
-    const type = nodeType as (VNodeTypes | typeof Teleport)
+    const type = nodeType as VNodeTypes | typeof Teleport
 
     // stub transition by default via config.global.stubs
     if (type === Transition && 'transition' in stubs && stubs['transition']) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -206,7 +206,7 @@ export function stubComponents(
           name: 'teleport-stub'
         }),
         undefined,
-        children
+        () => children
       ]
     }
 

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -2,6 +2,7 @@ import {
   transformVNodeArgs,
   Transition,
   TransitionGroup,
+  Teleport,
   h,
   ComponentPublicInstance,
   defineComponent,
@@ -9,7 +10,6 @@ import {
   ConcreteComponent,
   ComponentPropsOptions
 } from 'vue'
-import type { Teleport } from 'vue'
 import { hyphenate } from './utils/vueShared'
 import { matchName } from './utils/matchName'
 import { isComponent, isFunctionalComponent, isObjectComponent } from './utils'
@@ -200,7 +200,7 @@ export function stubComponents(
     }
 
     // stub teleport by default via config.global.stubs
-    if ((type as typeof Teleport).__isTeleport && 'teleport' in stubs && stubs['teleport']) {
+    if (type === Teleport && 'teleport' in stubs && stubs['teleport']) {
       return [
         createTeleportStub({
           name: 'teleport-stub'

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -419,33 +419,35 @@ describe('mounting options: stubs', () => {
     expect(wrapper.find('#content').exists()).toBe(true)
   })
 
-  it('stubs teleport by default', () => {
+  it('does not stub teleport by default', () => {
     const Comp = {
       template: `<teleport to="body"><div id="content" /></teleport>`
     }
     const wrapper = mount(Comp)
 
     expect(wrapper.html()).toBe(
-      '<teleport-stub>\n' +
-      '  <div id="content"></div>\n' +
-      '</teleport-stub>'
+      '<!--teleport start-->\n' +
+      '<!--teleport end-->'
     )
   })
 
-  it('opts out of stubbing teleport by default', () => {
+  it('opts in to stubbing teleport ', () => {
     const Comp = {
       template: `<teleport to="body"><div id="content" /></teleport>`
     }
     const wrapper = mount(Comp, {
       global: {
         stubs: {
-          teleport: false
+          teleport: true
         }
       }
     })
 
-    expect(wrapper.html()).toContain('<!--teleport start-->')
-    expect(wrapper.html()).toContain('<!--teleport end-->')
+    expect(wrapper.html()).toBe(
+      '<teleport-stub>\n' +
+      '  <div id="content"></div>\n' +
+      '</teleport-stub>'
+    )
   })
 
   it('stubs component by key prior before name', () => {

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -419,6 +419,35 @@ describe('mounting options: stubs', () => {
     expect(wrapper.find('#content').exists()).toBe(true)
   })
 
+  it('stubs teleport by default', () => {
+    const Comp = {
+      template: `<teleport to="body"><div id="content" /></teleport>`
+    }
+    const wrapper = mount(Comp)
+
+    expect(wrapper.html()).toBe(
+      '<teleport-stub>\n' +
+      '  <div id="content"></div>\n' +
+      '</teleport-stub>'
+    )
+  })
+
+  it('opts out of stubbing teleport by default', () => {
+    const Comp = {
+      template: `<teleport to="body"><div id="content" /></teleport>`
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          teleport: false
+        }
+      }
+    })
+
+    expect(wrapper.html()).toContain('<!--teleport start-->')
+    expect(wrapper.html()).toContain('<!--teleport end-->')
+  })
+
   it('stubs component by key prior before name', () => {
     const MyComponent = defineComponent({
       name: 'MyComponent',

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -426,8 +426,7 @@ describe('mounting options: stubs', () => {
     const wrapper = mount(Comp)
 
     expect(wrapper.html()).toBe(
-      '<!--teleport start-->\n' +
-      '<!--teleport end-->'
+      '<!--teleport start-->\n' + '<!--teleport end-->'
     )
   })
 
@@ -444,9 +443,7 @@ describe('mounting options: stubs', () => {
     })
 
     expect(wrapper.html()).toBe(
-      '<teleport-stub>\n' +
-      '  <div id="content"></div>\n' +
-      '</teleport-stub>'
+      '<teleport-stub>\n' + '  <div id="content"></div>\n' + '</teleport-stub>'
     )
   })
 


### PR DESCRIPTION
Adds stubbing support for the `teleport` Vue component

### Notes
Jest throws a warning:
```
  console.warn
    [Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance.
      at <TeleportStub>
      at <Anonymous ref="VTU_COMPONENT" >
      at <VTUROOT>
```

I believe this has something to do with how teleport consumes slots and how the renderer provides them, but I couldn't figure out exactly what the issue was. Providing them as an object with a function didn't solve it (i.e. `{ default: getSlots }`.

Teleport seems a bit special in Vue land, I think this is okay, but please make sure it is ;)