### PR TITLE
chore: remove circular import

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -139,7 +139,7 @@ export class VueWrapper<T extends ComponentPublicInstance>
       : this.element.querySelector && this.element.querySelector(selector)
 
     if (result) {
-      return new DOMWrapper(result)
+      return new DOMWrapper(result, createWrapper)
     }
 
     return createWrapperError('DOMWrapper')
@@ -214,11 +214,13 @@ export class VueWrapper<T extends ComponentPublicInstance>
       ? this.element.querySelectorAll(selector)
       : ([] as unknown as NodeListOf<Element>)
 
-    return Array.from(results).map((element) => new DOMWrapper(element))
+    return Array.from(results).map(
+      (element) => new DOMWrapper(element, createWrapper)
+    )
   }
 
   isVisible(): boolean {
-    const domWrapper = new DOMWrapper(this.element)
+    const domWrapper = new DOMWrapper(this.element, createWrapper)
     return domWrapper.isVisible()
   }
 


### PR DESCRIPTION
Inject `createVueWrapper`. A little less readable but gets rid of the circular imports, which in my experience, can lead to big problems.