### PR TITLE
fix(find): allow finding stubs by stub definition

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -277,7 +277,7 @@ export function mount(
   }
 
   addToDoNotStubComponents(component)
-  registerStub(originalComponent, component)
+  registerStub({ source: originalComponent, stub: component })
   const el = document.createElement('div')
 
   if (options?.attachTo) {

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -182,7 +182,23 @@ describe('findComponent', () => {
     })
 
     expect(wrapper.findComponent(Hello).exists()).toBe(true)
+    expect(wrapper.findAllComponents(Hello)).toHaveLength(1)
     expect(wrapper.findComponent(compB).exists()).toBe(true)
+    expect(wrapper.findAllComponents(compB)).toHaveLength(1)
+  })
+
+  it('finds a component by its stub', () => {
+    const HelloStub = defineComponent({ template: '<div>universal stub</div>' })
+
+    const wrapper = mount(compA, {
+      global: {
+        stubs: {
+          Hello: HelloStub
+        }
+      }
+    })
+
+    expect(wrapper.findComponent(HelloStub).exists()).toBe(true)
   })
 
   it('finds a component without a name by its locally assigned name', () => {


### PR DESCRIPTION
Long-long ago, in the galaxy far-far away it started pretty simple: we've passed a stub for a component and VTU rendered this stub via `transformVNodeArgs` provided by Vue core:

![Untitled-2021-11-29-1408](https://user-images.githubusercontent.com/200997/143872505-1126ada2-737e-4007-8f54-b949028800a2.png)

We were able to find stub by stub (obviously, because VNode matched) and component by stub because [we've tracked relation between component and it's stub](https://github.com/vuejs/vue-test-utils-next/pull/696) (blue line)

Unfortunately, soon we've discovered that sometimes people use same stub for stubbing multiple components:

![Untitled-2021-11-29-1408-1](https://user-images.githubusercontent.com/200997/143872916-ad1f2bee-acf4-41b3-a2f9-0b8ffe616643.png)

This was a problem, because we were unable to tell, if `Stub 1` was the stub of `Original component 1` or `Original component 2`

So, we've [introduced](https://github.com/vuejs/vue-test-utils-next/pull/705) a "specialized stub" concept - it is simply a copy of original stub, so for each original component stub is "unique":

![Untitled-2021-11-29-1408-2](https://user-images.githubusercontent.com/200997/143873106-32574d85-1f86-4caf-9dcf-b04f646884be.png)

We were still tracking relation between specialized stubs and original components (red dotted line) to keep everything consistent.

Unfortunately, this broke use case, when people are searching stubs by passing stub as component - if stub has no name, it will not match anything (and it worked in VTU v1). So this PR is pretty simple: it adds tracking relations between specialized stubs and stubs too, so we could match specialized stubs when searching for stubs (green dotted line):

![Untitled-2021-11-29-1408-3](https://user-images.githubusercontent.com/200997/143873347-157f0503-469d-4a0e-86fd-4e03dcaebcd9.png)

