### PR TITLE
Fix: Use defaultName when it exists to correctly stub async components

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -138,7 +138,7 @@ const getComponentName = (instance: any | null, type: VNodeTypes): string => {
       (key) => instance.setupState[key] === type
     )
 
-    return type.name || defaultName || ''
+    return defaultName || type.name || ''
   }
 
   if (isLegacyExtendedComponent(type)) {

--- a/tests/components/ScriptSetupWithChildren.vue
+++ b/tests/components/ScriptSetupWithChildren.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineAsyncComponent } from '@vue/compat'
+import { defineAsyncComponent } from 'vue'
 
 import Hello from './Hello.vue'
 import ComponentWithInput from './ComponentWithInput.vue'

--- a/tests/components/ScriptSetupWithChildren.vue
+++ b/tests/components/ScriptSetupWithChildren.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import { defineAsyncComponent } from '@vue/compat'
+
 import Hello from './Hello.vue'
 import ComponentWithInput from './ComponentWithInput.vue'
 import ComponentWithoutName from './ComponentWithoutName.vue'
+const ComponentAsync = defineAsyncComponent(() => import('./ComponentWithoutName.vue'))
 import ScriptSetup from './ScriptSetup.vue'
 import WithProps from './WithProps.vue'
 </script>
@@ -10,6 +13,7 @@ import WithProps from './WithProps.vue'
   <hello />
   <component-with-input />
   <component-without-name />
+  <component-async />
   <script-setup />
   <with-props />
 </template>

--- a/tests/components/ScriptSetupWithChildren.vue
+++ b/tests/components/ScriptSetupWithChildren.vue
@@ -4,7 +4,9 @@ import { defineAsyncComponent } from 'vue'
 import Hello from './Hello.vue'
 import ComponentWithInput from './ComponentWithInput.vue'
 import ComponentWithoutName from './ComponentWithoutName.vue'
-const ComponentAsync = defineAsyncComponent(() => import('./ComponentWithoutName.vue'))
+const ComponentAsync = defineAsyncComponent(
+  () => import('./ComponentWithoutName.vue')
+)
 import ScriptSetup from './ScriptSetup.vue'
 import WithProps from './WithProps.vue'
 </script>

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -161,6 +161,7 @@ describe('shallowMount', () => {
       '<div>Override</div>\n' +
         '<component-with-input-stub></component-with-input-stub>\n' +
         '<component-without-name-stub></component-without-name-stub>\n' +
+        '<component-async-stub></component-async-stub>\n' +
         '<script-setup-stub></script-setup-stub>\n' +
         '<with-props-stub></with-props-stub>'
     )


### PR DESCRIPTION
When mounting a component that has components defined with `defineAsyncComponent` the result of `type.name` is `AsyncComponentWrapper`. The `defaultName` contains the filename which should get precedence over the `type.name` to make stubbing work correctly.