### PR TITLE
fix: Remove `methods` key from mount

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -57,6 +57,13 @@ const MOUNT_OPTIONS: Array<keyof MountingOptions<any>> = [
 function getInstanceOptions(
   options: MountingOptions<any> & Record<string, any>
 ): Record<string, any> {
+  if (options.methods) {
+    console.warn(
+      "Passing a `methods` option to mount was deprecated on Vue Test Utils v1, and it won't have any effect on v2. For additional info: https://vue-test-utils.vuejs.org/upgrading-to-v1/#setmethods-and-mountingoptions-methods"
+    )
+    delete options.methods
+  }
+
   const resultOptions = { ...options }
   for (const key of Object.keys(options)) {
     if (MOUNT_OPTIONS.includes(key as keyof MountingOptions<any>)) {
@@ -65,6 +72,7 @@ function getInstanceOptions(
   }
   return resultOptions
 }
+
 // Class component - no props
 export function mount<V>(
   originalComponent: {

--- a/tests/mountingOptions/options.spec.ts
+++ b/tests/mountingOptions/options.spec.ts
@@ -10,4 +10,24 @@ describe('mounting options: other', () => {
     })
     expect(wrapper.vm.$options.someUnknownOption).toBe(optionContent)
   })
+
+  it('warns on deprecated `method` option and methods are preserved', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+
+    const TestComponent = defineComponent({
+      template: '<div>{{ sayHi() }}</div>',
+      methods: {
+        sayHi() {
+          return 'hi'
+        }
+      }
+    })
+
+    const wrapper = mount(TestComponent, { methods: {} })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(wrapper.html()).toBe('<div>hi</div>')
+
+    spy.mockRestore()
+  })
 })


### PR DESCRIPTION
Closes #1104

`methods` is not a valid key in Vue Test Utils v2, but it existed in 0.x versions and some people got used to it. Thus, providing a warning message will help anyone updating their projects (or mental model!).

Any suggestion is more than welcome :) 