### PR TITLE
chore: use experimentalExposeScriptSetupContext for vue-tsc

### DIFF
--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -1,5 +1,4 @@
 import {
-  DefineComponent,
   defineComponent,
   FunctionalComponent,
   getCurrentInstance,
@@ -346,16 +345,23 @@ describe('emitted', () => {
     expect(wrapper.emitted('click')).toHaveLength(1)
   })
 
-  it.each([EmitsEventSFC, EmitsEventScriptSetup] as DefineComponent[])(
-    'captures emitted events',
-    async (component) => {
-      const wrapper = mount(component)
-      await wrapper.trigger('click')
+  it('captures emitted events in SFC', async () => {
+    const wrapper = mount(EmitsEventSFC)
+    await wrapper.trigger('click')
 
-      expect(wrapper.emitted().click).toHaveLength(1)
-      expect(wrapper.emitted().bar).toHaveLength(2)
-      expect(wrapper.emitted().bar[0]).toEqual(['mounted'])
-      expect(wrapper.emitted().bar[1]).toEqual(['click'])
-    }
-  )
+    expect(wrapper.emitted().click).toHaveLength(1)
+    expect(wrapper.emitted().bar).toHaveLength(2)
+    expect(wrapper.emitted().bar[0]).toEqual(['mounted'])
+    expect(wrapper.emitted().bar[1]).toEqual(['click'])
+  })
+
+  it('captures emitted events in script setup', async () => {
+    const wrapper = mount(EmitsEventScriptSetup)
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted().click).toHaveLength(1)
+    expect(wrapper.emitted().bar).toHaveLength(2)
+    expect(wrapper.emitted().bar[0]).toEqual(['mounted'])
+    expect(wrapper.emitted().bar[1]).toEqual(['click'])
+  })
 })

--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -25,10 +25,11 @@ describe('expose', () => {
     const wrapper = mount(DefineExposeWithRenderFunction)
 
     // other is exposed vie `expose`
+    // @ts-ignore upstream issue, see https://github.com/vuejs/vue-next/issues/4397#issuecomment-957613874
     expect(wrapper.vm.other).toBe('other')
     // can't access `msg` as it is not exposed
     // and we are in a component with a setup returning a render function
-    expect(wrapper.vm.msg).toBeUndefined()
+    expect((wrapper.vm as unknown as { msg: undefined }).msg).toBeUndefined()
   })
 
   it('access vm with <script setup> and defineExpose()', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,8 @@
     "tests",
     "src",
     "types"
-  ]
+  ],
+  "vueCompilerOptions": {
+    "experimentalExposeScriptSetupContext": true
+  }
 }

--- a/tsconfig.volar.json
+++ b/tsconfig.volar.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2020"],
     "skipLibCheck": true
-  },
-  "exclude": ["tests/expose.spec.ts"]
+  }
 }


### PR DESCRIPTION
This new option allows a better typechecking of components that expose variables.
See https://github.com/johnsoncodehk/volar/issues/805

Refs #972 as this partially fixes it