### PR TITLE
chore: bump to vue-tsc 0.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vue-class-component": "^8.0.0-rc.1",
     "vue-jest": "^5.0.0-alpha.10",
     "vue-router": "^4.0.12",
-    "vue-tsc": "0.30.0",
+    "vue-tsc": "0.30.1",
     "vuex": "^4.0.2"
   },
   "peerDependencies": {

--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -47,6 +47,7 @@ describe('expose', () => {
     await wrapper.find('button').trigger('click')
     expect(wrapper.html()).toContain('1')
     // can access `count` even if it is _not_ exposed
+    // @ts-ignore we need better types here, see https://github.com/vuejs/vue-test-utils-next/issues/972
     expect(wrapper.vm.count).toBe(1)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,5 @@
     "tests",
     "src",
     "types"
-  ],
-  "vueCompilerOptions": {
-    "experimentalExposeScriptSetupContext": true
-  }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,56 +1553,56 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.0.1.tgz#db0e5eacf96358e04cc501c9008079b25a70a4ac"
   integrity sha512-wtdMnGVvys9K8tg+DxowU1ytTrdVveXr3LzdhaKakysgGXyrsfaeds2cDywtvujEASjWOwWL/OgWM+qoeM8Plg==
 
-"@volar/code-gen@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.30.0.tgz#98be88e72dff2e5a66b18f204523655b4122a065"
-  integrity sha512-5Wl32LebqeGe1a30TGX8DDB28lUyBJ/jX1GazInkj6O605FomWXu/ju/0WTJH2L+wjD09ZND79iuFmTna2UXMw==
+"@volar/code-gen@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.30.1.tgz#1e9c073e4fba2f8b861eb9413dd18aea8b8fe2ca"
+  integrity sha512-qPT0ZGzLaaUArZ1b5qcso2GAFpgjxsPDRXnq0lgsSOpNO6lXJN5ZcWzFZXYPjMJSV1Rkm0ehK5tSUD+sD+pPWg==
   dependencies:
-    "@volar/shared" "0.30.0"
-    "@volar/source-map" "0.30.0"
+    "@volar/shared" "0.30.1"
+    "@volar/source-map" "0.30.1"
 
-"@volar/html2pug@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.30.0.tgz#0c8a1d61daaaca1120aea5f19018f59b2a7bcc64"
-  integrity sha512-MchpYvwqv5V6P6l1c0fPIFhZ8ahLXCR6lWTb4ZRtvUdMFjJH0yXzkrb6U8UghzdV7Yok/nJuf2Unf4DmU+sTjw==
+"@volar/html2pug@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/html2pug/-/html2pug-0.30.1.tgz#06bc4368b8eac39bda87323dd0214f0a511d2006"
+  integrity sha512-ojJPrb4qSLrVNl9LTtdjZ5MFyeHmwJK4OVPTgFc/lyQ94nPS9JHba86SaTwDb2XEgiXBWQVEo12bRr3lW9H2+Q==
   dependencies:
     domelementtype "^2.2.0"
     domhandler "^4.2.2"
     htmlparser2 "^7.1.2"
     pug "^3.0.2"
 
-"@volar/shared@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.30.0.tgz#57099dc8d8c63fbccbd958002f22d827dc33413a"
-  integrity sha512-zfQMIQWAbRd/u8iqKFUd/24EGEDKwr6QuKwEoXe1/UAhA8TIWBljnfm/pgMdyUzWPqnNFKeFLRHMlt8NUoDHJQ==
+"@volar/shared@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.30.1.tgz#05b5121033723b9474a2ac12829f9d72cfa34e33"
+  integrity sha512-6F5yQYeN+gbXAKplxHDvj4Ei+rHCjNhwkfZnGpaSpEU92uSI2vK/HfEdd/zTKdAZpwz0RjliNuFoXLi6umtQ0w==
   dependencies:
     upath "^2.0.1"
     vscode-jsonrpc "^8.0.0-next.2"
     vscode-uri "^3.0.2"
 
-"@volar/source-map@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.30.0.tgz#0c854868aac7b46274c9f1ff9a64d8ddd9ea94a7"
-  integrity sha512-uS/+4+pyGhcUPjKZLcUfccyqGD2iUoGRRljCW9qJKUJ+PGQh2HvjYzMzX2tBSqZ6LaRZZw8kIVidzSQdFfpK/g==
+"@volar/source-map@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.30.1.tgz#321d78f7a330c4916827439aaa54b5b1f9abd21e"
+  integrity sha512-QGi36KBGHZ4gq81jPSi3W2wRcpso9Apd59AZOv/H98k5hU9zo8wA5hwartZHiybTlT1q/0Yno3agSj+vK2vocw==
   dependencies:
-    "@volar/shared" "0.30.0"
+    "@volar/shared" "0.30.1"
 
-"@volar/transforms@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.30.0.tgz#f69b5a69a30e8a6044f52a3df1b3c7a1f6fbb524"
-  integrity sha512-Jnbh/lYt91bzbq7pJMkApG8laWe4+gAqMhsgi+Ulitu98fvdZKlc+qseSa2kezfUN+565pQpuMk5FPT2c1tFCQ==
+"@volar/transforms@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.30.1.tgz#9e74452d42efea0a19a4261fd5eec50b923c5b46"
+  integrity sha512-dWFyfQGLoZ8LZI93zud0c5uoCdlkwDBi90G/XaaKfXxkX+3eiJrM0lJ/d1Nc0L04t9mb28I5hpVK68vH90+Tlw==
   dependencies:
-    "@volar/shared" "0.30.0"
+    "@volar/shared" "0.30.1"
     vscode-languageserver "^8.0.0-next.2"
 
-"@volar/vue-code-gen@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.30.0.tgz#8939b810bb333cc23f3875e8533155bb9e03f72d"
-  integrity sha512-PK4wMPrxzJMVrkVUYoZQvGAVLaXrmRdaeFqa02nMeGrdjjrg6XX8vAmgQ34/ZNUMV/oMWm7soQ0n7BN0Vab/iA==
+"@volar/vue-code-gen@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.30.1.tgz#03b973794f45334bec86d7533f5accddffe7110f"
+  integrity sha512-+0egr84YOYLudP6jRXRm+xtAL92GTPaq0U0lsorLTBp/MB14Fap6HMUr/LEeNB5tnND36UQJiUWHM5eTDAAb4Q==
   dependencies:
-    "@volar/code-gen" "0.30.0"
-    "@volar/shared" "0.30.0"
-    "@volar/source-map" "0.30.0"
+    "@volar/code-gen" "0.30.1"
+    "@volar/shared" "0.30.1"
+    "@volar/source-map" "0.30.1"
     "@vue/compiler-core" "^3.2.21"
     "@vue/compiler-dom" "^3.2.21"
     "@vue/shared" "^3.2.21"
@@ -6386,25 +6386,25 @@ vscode-nls@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-pug-languageservice@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.30.0.tgz#d8e12a99d3a4a00ee9ad0971b5055d5b306e31b5"
-  integrity sha512-vSBf4ZXIUDK/COxAMkIe5wDKWNQUcdjndir/r3MoknEuC0LLE8GEH80x25yAGMXnMDhXUwL+ekCOzgb4RH6upA==
+vscode-pug-languageservice@0.30.1:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/vscode-pug-languageservice/-/vscode-pug-languageservice-0.30.1.tgz#70eb801a17a73bfe0fe7830fca0cc4451143621f"
+  integrity sha512-ytco+lziRQNrpHpI8X+/rhYaX4KUWAnYZHd1f1epu2m+9WoIf9swbk8/slIOeyec1DPg4Y7AS8hTLcEfOfY71g==
   dependencies:
-    "@volar/code-gen" "0.30.0"
-    "@volar/shared" "0.30.0"
-    "@volar/source-map" "0.30.0"
-    "@volar/transforms" "0.30.0"
+    "@volar/code-gen" "0.30.1"
+    "@volar/shared" "0.30.1"
+    "@volar/source-map" "0.30.1"
+    "@volar/transforms" "0.30.1"
     pug-lexer "^5.0.1"
     pug-parser "^6.0.0"
     vscode-languageserver "^8.0.0-next.2"
 
-vscode-typescript-languageservice@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.30.0.tgz#131f6fc4b914255908d7954ddbb6948c2958b09b"
-  integrity sha512-Os+1yxz7+xZLeUNPS/cpiUsOxrSFIC6s79ir56W3QWd9jV/jcL1rt69Wsz8AilmQ7zSA9Cri5wqOb4VHj8IICQ==
+vscode-typescript-languageservice@0.30.1:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.30.1.tgz#02635642e07aab3267f48402f850a972d1b20c39"
+  integrity sha512-7EBJiaLXThlrbm2K5VU+qWPR3z+RtmCFLWiZaNdJYO/E5UFBQiPmO8qXlxcB2x1N7zId2GZoogAbT15oexY2eQ==
   dependencies:
-    "@volar/shared" "0.30.0"
+    "@volar/shared" "0.30.1"
     semver "^7.3.5"
     upath "^2.0.1"
     vscode-languageserver "^8.0.0-next.2"
@@ -6420,17 +6420,17 @@ vscode-uri@^3.0.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
   integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
-vscode-vue-languageservice@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.30.0.tgz#691d58415216eb676173296b0b5ef59d8fbf8366"
-  integrity sha512-1O7wv3nrQxRwwuFXdWcBqj+szl3Hs/FrvoP3AkUNfMuY9ZPRNvqhObekcizzOCSe1vM1bZxXPai/5NeW/6AOkA==
+vscode-vue-languageservice@0.30.1:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/vscode-vue-languageservice/-/vscode-vue-languageservice-0.30.1.tgz#734c7374f6f70564598603ecf23f52a7338f2c2b"
+  integrity sha512-l9R5vXkrGY0N4hA2o9ZFBIKL44z7UbHc45YjOmnslGwYL15YXfb7T4quW8VYSWJNRbiFBTNnNLWORIDEcWazBA==
   dependencies:
-    "@volar/code-gen" "0.30.0"
-    "@volar/html2pug" "0.30.0"
-    "@volar/shared" "0.30.0"
-    "@volar/source-map" "0.30.0"
-    "@volar/transforms" "0.30.0"
-    "@volar/vue-code-gen" "0.30.0"
+    "@volar/code-gen" "0.30.1"
+    "@volar/html2pug" "0.30.1"
+    "@volar/shared" "0.30.1"
+    "@volar/source-map" "0.30.1"
+    "@volar/transforms" "0.30.1"
+    "@volar/vue-code-gen" "0.30.1"
     "@vscode/emmet-helper" "^2.8.0"
     "@vue/reactivity" "^3.2.21"
     "@vue/shared" "^3.2.21"
@@ -6441,8 +6441,8 @@ vscode-vue-languageservice@0.30.0:
     vscode-json-languageservice "^4.1.8"
     vscode-languageserver "^8.0.0-next.2"
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-pug-languageservice "0.30.0"
-    vscode-typescript-languageservice "0.30.0"
+    vscode-pug-languageservice "0.30.1"
+    vscode-typescript-languageservice "0.30.1"
 
 vue-class-component@^8.0.0-rc.1:
   version "8.0.0-rc.1"
@@ -6468,13 +6468,13 @@ vue-router@^4.0.12:
   dependencies:
     "@vue/devtools-api" "^6.0.0-beta.18"
 
-vue-tsc@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-0.30.0.tgz#fc28c09a5c4ee9b786e24ba053f43ae70ccbecc6"
-  integrity sha512-gtak7jRYpoERneZIItE+UoLPjV2Ba73nTA/MUzR+Wg3JnINhP4xgke+VHesM2JVTkABmAwj3yyaiMjDP0pY9jA==
+vue-tsc@0.30.1:
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-0.30.1.tgz#c47011c4190bf70c11865a2d8cdc3cac635b4771"
+  integrity sha512-AVBPWF70LvuzAt6phaF3U8pg1WmjmZQBfZvkX4Ve9EHTPh4R2JiJnSjf3MQgnx03qF5w0PGkBJ90l12aaLZeKQ==
   dependencies:
-    "@volar/shared" "0.30.0"
-    vscode-vue-languageservice "0.30.0"
+    "@volar/shared" "0.30.1"
+    vscode-vue-languageservice "0.30.1"
 
 vue@3.2.26, vue@^3.2.26:
   version "3.2.26"


### PR DESCRIPTION
As the `experimentalExposeScriptSetupContext` has been removed, we need to workaround a type checking error