### PR TITLE
fix: globalProperties config leak (#1187)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,26 @@ function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
   }
 }
 
+// perform 1-level-deep-pseudo-clone merge in order to prevent config leaks
+// example: vue-router overwrites globalProperties.$router
+function mergeAppConfig(
+  configGlobalConfig: GlobalMountOptions['config'],
+  mountGlobalConfig: GlobalMountOptions['config']
+): Required<GlobalMountOptions>['config'] {
+  return {
+    ...configGlobalConfig,
+    ...mountGlobalConfig,
+    globalProperties: {
+      ...configGlobalConfig?.globalProperties,
+      ...mountGlobalConfig?.globalProperties
+    },
+    compilerOptions: {
+      ...configGlobalConfig?.compilerOptions,
+      ...mountGlobalConfig?.compilerOptions
+    }
+  }
+}
+
 export function mergeGlobalProperties(
   mountGlobal: GlobalMountOptions = {}
 ): Required<GlobalMountOptions> {
@@ -34,7 +54,7 @@ export function mergeGlobalProperties(
     components: { ...configGlobal.components, ...mountGlobal.components },
     provide: { ...configGlobal.provide, ...mountGlobal.provide },
     mocks: { ...configGlobal.mocks, ...mountGlobal.mocks },
-    config: { ...configGlobal.config, ...mountGlobal.config },
+    config: mergeAppConfig(configGlobal.config, mountGlobal.config),
     directives: { ...configGlobal.directives, ...mountGlobal.directives },
     renderStubDefaultSlot
   }


### PR DESCRIPTION
This PR fixes #1187 by doing 1st-level-pseudo-deep-clone merge of Vue's AppConfig (only the props that we know are objects - `globalProperties` and `compilerOptions`).

I was tempted to use lodash's `clondeDeep` but didn't want to bring another dependency. (looked at `lodash.clonedeep` as well but the `lodash.*` packages are not updated anymore). Not loving how `mergeAppConfig()` turned out but it does the job without additional dependencies. Open to alternatives :) 

This might break existing tests if they rely on the buggy behavior but i don't think it should be considered breaking changes 🤔


**Copy of the original issue and repro:**
> Thanks for the great work, guys! 🙇 I just noticed that when i pass the router plugin in a test, then the rest of the tests were inheriting the router.
> 
> ```js
> mount(Component, { global: { plugins: [router] }})
> ```
> 
> I also have a global config setup:
> 
> ```js
> config.global.config.globalProperties = {
>   $router: routerMock,
>   $route: routeMock,
> }
> ```
> 
> I believe it has sth to do with the config merging strategy - it uses shallow clone and in the case of deeply nested objects, it overwrites the VTU's global config object. This might not be limited to plugins/config/globalProperties but other parts of the config as well 🤔
> 
> Here's how to reproduce:
> 
> ```js
> import { config, mount } from '@vue/test-utils'
> import { h } from 'vue'
> 
> config.global.config.globalProperties = {
>   $anotherThing: 'not used but sth to demonstrate a non-empty global config',
> }
> 
> const Plugin = {
>   install(app) {
>     app.config.globalProperties.$something = 'something'
>   },
> }
> 
> const Component = {
>   render() {
>     return h('div', this.$something)
>   },
> }
> 
> test('should pass with plugin', () => {
>   const wrapper = mount(Component, {
>     global: {
>       plugins: [Plugin],
>     },
>   })
> 
>   expect(wrapper.html()).toContain('something')
> })
> 
> test('should pass without plugin but it fails!', () => {
>   const wrapper = mount(Component)
> 
>   expect(wrapper.html()).not.toContain('something')
> })
> ```