### PR TITLE
chore: drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Some dependencies are no longer compatible with Node v12 (vscode-jsonrpc).
Its end of life is in 3 months anyway.

This is what create-vue did as well: https://github.com/vuejs/create-vue/commit/cea1dcc1b1b4e7a33bea0db9a4febae88bae626a

This will allow #1209 to get merged