### PR TITLE
fix: findAll root nodes when using render function

### DIFF
--- a/tests/components/MultipleRootRender.vue
+++ b/tests/components/MultipleRootRender.vue
@@ -1,0 +1,14 @@
+<template>
+  <render></render>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+
+const render = () => [
+  h('a', {}, 'first'),
+  h('a', {}, 'second'),
+  h('a', {}, 'third'),
+  h('span', {}, 'other span')
+]
+</script>

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -2,6 +2,7 @@ import { defineComponent, h, nextTick, Fragment } from 'vue'
 
 import { mount, VueWrapper } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
+import MultipleRootRender from './components/MultipleRootRender.vue'
 
 describe('find', () => {
   it('find using single root node', () => {
@@ -155,6 +156,11 @@ describe('find', () => {
     const wrapper = mount(Component)
     const etc = wrapper.findComponent({ name: 'EmptyTestComponent' })
     expect(etc.find('p').exists()).toBe(false)
+  })
+
+  it('finds root node with SFC render function', () => {
+    const wrapper = mount(MultipleRootRender)
+    expect(wrapper.find('a').exists()).toBe(true)
   })
 })
 
@@ -334,6 +340,11 @@ describe('findAll', () => {
           .find('.target2')
           .exists()
       ).toBe(true)
+    })
+
+    it('finds all root nodes with SFC render function', () => {
+      const wrapper = mount(MultipleRootRender)
+      expect(wrapper.findAll('a')).toHaveLength(3)
     })
   })
 })


### PR DESCRIPTION
This PR will fix #1201.

I just used the same logic of `find` for `findAll` and unified this into one method. So same logic for `find` and `findAll` (except ref selector for `find`)